### PR TITLE
Off by one error computing width of SPI `addr_mask`.

### DIFF
--- a/embedded-registers/src/spi/codecs/simple_codec.rs
+++ b/embedded-registers/src/spi/codecs/simple_codec.rs
@@ -52,7 +52,7 @@ impl<
         R: Register,
     {
         // create a mask with ADDR_MSB ones.
-        let addr_mask = u64::checked_shl(1, ADDR_MSB as u32).unwrap_or(0).wrapping_sub(1);
+        let addr_mask = u64::checked_shl(1, ADDR_MSB as u32 + 1).unwrap_or(0).wrapping_sub(1);
         // Shift the address to the correct place
         let addr_shifted = (R::ADDRESS << ADDR_LSB) & addr_mask;
         // incorporate addess


### PR DESCRIPTION
I'm bringing up a BME280 over SPI, and wasn't getting the right chip ID response. Looking at the SPI transactions on the logic analyzer, I was seeing MOSI sending [0x20, 0xb6], clearly the reset command due to the magic value transmitted in the second byte. But the register address bit 6 was zeroed. Eventually I found that the SPI SimpleCodec was computing a mask value that was short of the most significant bit. That perfectly explained the missing bit, and once I added this patch, the sensor is passing the chip ID test and providing me with measurements.