### PR TITLE
Fix example link in README

### DIFF
--- a/embedded-devices/README.md
+++ b/embedded-devices/README.md
@@ -32,7 +32,7 @@ I2C/SPI.
 
 ## Examples
 
-An example project for the esp32 is included at [examples](./examples)
+An example project for the esp32 is included in the [examples](https://github.com/oddlama/embedded-devices/tree/main/examples).
 
 ## Supported Devices
 


### PR DESCRIPTION
This worked from the main GitHub page, but not when browsing the README from the `./embedded-devices` folder.