### PR TITLE
feat: add feature flags for supported devices

### DIFF
--- a/embedded-devices/Cargo.toml
+++ b/embedded-devices/Cargo.toml
@@ -26,5 +26,29 @@ uom = { version = "0.36.0", features = ["f32", "f64", "si", "u8", "u16", "u32", 
 
 [features]
 async = ["embedded-registers/async"]
-default = ["async", "embedded-registers/async"]
+default = ["async"]
 std = []
+
+# Supported Devices
+# analog devices
+analog_devices-max31865 = []
+
+# Bosch
+bosch-bme280 = []
+bosch-bmp280 = ["bosch-bme280"]
+bosch-bmp390 = []
+
+# Microchip
+microchip-mcp9808 = []
+microchip-mcp3204 = []
+microchip-mcp3208 = []
+
+# Texas Instrument
+texas_instruments-ina219 = []
+texas_instruments-ina228 = []
+texas_instruments-tmp102 = []
+texas_instruments-tmp117 = []
+
+[package.metadata.docs.rs]
+
+all-features = true

--- a/embedded-devices/src/devices/analog_devices/mod.rs
+++ b/embedded-devices/src/devices/analog_devices/mod.rs
@@ -1,1 +1,2 @@
+#[cfg(feature = "analog_devices-max31865")]
 pub mod max31865;

--- a/embedded-devices/src/devices/bosch/mod.rs
+++ b/embedded-devices/src/devices/bosch/mod.rs
@@ -1,3 +1,6 @@
+#[cfg(feature = "bosch-bme280")]
 pub mod bme280;
+#[cfg(feature = "bosch-bmp280")]
 pub mod bmp280;
+#[cfg(feature = "bosch-bmp390")]
 pub mod bmp390;

--- a/embedded-devices/src/devices/microchip/mod.rs
+++ b/embedded-devices/src/devices/microchip/mod.rs
@@ -1,3 +1,6 @@
+#[cfg(feature = "microchip-mcp3204")]
 pub mod mcp3204;
+#[cfg(feature = "microchip-mcp3208")]
 pub mod mcp3208;
+#[cfg(feature = "microchip-mcp9808")]
 pub mod mcp9808;

--- a/embedded-devices/src/devices/texas_instruments/mod.rs
+++ b/embedded-devices/src/devices/texas_instruments/mod.rs
@@ -1,4 +1,8 @@
+#[cfg(feature = "texas_instruments-ina219")]
 pub mod ina219;
+#[cfg(feature = "texas_instruments-ina228")]
 pub mod ina228;
+#[cfg(feature = "texas_instruments-tmp102")]
 pub mod tmp102;
+#[cfg(feature = "texas_instruments-tmp117")]
 pub mod tmp117;

--- a/embedded-devices/src/lib.rs
+++ b/embedded-devices/src/lib.rs
@@ -10,13 +10,11 @@ pub mod utils;
 
 #[cfg(test)]
 mod tests {
-    use crate::devices::bosch::{
-        bme280::registers::{Reset, ResetBitfield, ResetMagic},
-        bmp390::registers::{Error, ErrorBitfield, Pressure, PressureBitfield},
-    };
 
+    #[cfg(feature = "bosch-bme280")]
     #[test]
     fn register_bme280_reset() {
+        use crate::devices::bosch::bme280::registers::{Reset, ResetBitfield, ResetMagic};
         let value = ResetBitfield {
             magic: ResetMagic::Reset,
         };
@@ -26,8 +24,10 @@ mod tests {
         assert_eq!(reg.read_all(), value);
     }
 
+    #[cfg(feature = "bosch-bmp390")]
     #[test]
     fn register_bmp390_error() {
+        use crate::devices::bosch::bmp390::registers::{Error, ErrorBitfield, Pressure, PressureBitfield};
         let value = ErrorBitfield {
             fatal_err: true,
             cmd_err: false,
@@ -40,8 +40,10 @@ mod tests {
         assert_eq!(reg.read_all(), value);
     }
 
+    #[cfg(feature = "bosch-bmp390")]
     #[test]
     fn register_bmp390_pressure() {
+        use crate::devices::bosch::bmp390::registers::{Error, ErrorBitfield, Pressure, PressureBitfield};
         let value = PressureBitfield { pressure: 0x123456 };
 
         let reg = Pressure::new(value.clone());
@@ -49,6 +51,7 @@ mod tests {
         assert_eq!(reg.read_all(), value);
     }
 
+    #[cfg(feature = "texas_instruments-ina228")]
     #[test]
     fn register_defaults() {
         use crate::devices::texas_instruments::ina228::registers::AdcConfiguration;


### PR DESCRIPTION
As per your todos, this implements separate feature flags for all currently supported devices.
This way one only needs to pull the necesarry devices when using and isn't compiling everything.

Downsides are that currently the tests need to be run using `cargo test --all-features` to enable
the corresponding tests, and that per default this crate now does nothing, you have to set the needed
everytime.

Hope the name are ok and I didn't break anything I didn't expect.
