### PR TITLE
Add support for sensirion SCD4x devices

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12,6 +12,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "arrayvec"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
+
+[[package]]
 name = "autocfg"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -208,6 +214,7 @@ dependencies = [
 name = "embedded-registers"
 version = "0.9.12"
 dependencies = [
+ "arrayvec",
  "bondrewd",
  "bytemuck",
  "crc",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -79,6 +79,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "crc"
+version = "3.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69e6e4d7b33a94f0991c26729976b10ebde1d34c3ee82408fb536164fa10d636"
+dependencies = [
+ "crc-catalog",
+]
+
+[[package]]
+name = "crc-catalog"
+version = "2.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19d374276b40fb8bbdee95aef7c7fa6b5316ec764510eb64b8dd0e2ed0d7e7f5"
+
+[[package]]
 name = "darling"
 version = "0.20.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -152,6 +167,7 @@ dependencies = [
  "approx",
  "bondrewd",
  "bytemuck",
+ "crc",
  "defmt",
  "embedded-devices-derive",
  "embedded-hal",
@@ -194,6 +210,7 @@ version = "0.9.12"
 dependencies = [
  "bondrewd",
  "bytemuck",
+ "crc",
  "defmt",
  "embedded-hal",
  "embedded-hal-async",

--- a/TODO.md
+++ b/TODO.md
@@ -8,3 +8,4 @@
 - all defmt derives only if defmt feature is enabled
 - workspace dependencies for stuff that is needed all the time, bondrewd, embedded-hal, maybe-async-cfg, ...
 - make #[register(default = )] add a #[doc] annotation
+- remove i2c! macro. too inflexible to provide real benefit.

--- a/embedded-devices/Cargo.toml
+++ b/embedded-devices/Cargo.toml
@@ -23,6 +23,7 @@ embedded-registers = { version = "0.9.12", path = "../embedded-registers", defau
 maybe-async-cfg = "0.2.5"
 paste = "1.0.15"
 uom = { version = "0.36.0", features = ["f32", "f64", "si", "u8", "u16", "u32", "u64", "i8", "i16", "i32", "i64", "rational32", "rational64"], default-features = false }
+crc = "3.2.1"
 
 [features]
 default = ["sync", "async"]
@@ -51,6 +52,9 @@ texas_instruments-ina219 = []
 texas_instruments-ina228 = []
 texas_instruments-tmp102 = []
 texas_instruments-tmp117 = []
+
+# Sensirion
+sensirion-scd4x = []
 
 [package.metadata.docs.rs]
 all-features = true

--- a/embedded-devices/src/devices/bosch/bme280/mod.rs
+++ b/embedded-devices/src/devices/bosch/bme280/mod.rs
@@ -162,6 +162,7 @@ pub struct BME280Common<I: embedded_registers::RegisterInterface, const IS_BME: 
 /// a footprint of only 2.5 × 2.5 mm² with a height of 0.93 mm. Its small dimensions and its low power
 /// consumption allow the implementation in battery driven devices such as handsets, GPS modules or
 /// watches.
+#[cfg(feature = "sync")]
 pub type BME280Sync<I> = BME280CommonSync<I, true>;
 
 /// The BME280 is a combined digital humidity, pressure and temperature sensor based on proven
@@ -169,16 +170,17 @@ pub type BME280Sync<I> = BME280CommonSync<I, true>;
 /// a footprint of only 2.5 × 2.5 mm² with a height of 0.93 mm. Its small dimensions and its low power
 /// consumption allow the implementation in battery driven devices such as handsets, GPS modules or
 /// watches.
+#[cfg(feature = "async")]
 pub type BME280Async<I> = BME280CommonAsync<I, true>;
 
 /// Common configuration values for the BME280 sensor.
 #[derive(Debug, Clone)]
 pub struct Configuration {
-    /// The oversampling rate for temperature mesurements
+    /// The oversampling rate for temperature measurements
     pub temperature_oversampling: Oversampling,
-    /// The oversampling rate for pressure mesurements
+    /// The oversampling rate for pressure measurements
     pub pressure_oversampling: Oversampling,
-    /// The oversampling rate for humidity mesurements
+    /// The oversampling rate for humidity measurements
     pub humidity_oversampling: Oversampling,
     /// The iir filter to use
     pub iir_filter: IIRFilter,

--- a/embedded-devices/src/devices/microchip/mcp9808/address.rs
+++ b/embedded-devices/src/devices/microchip/mcp9808/address.rs
@@ -11,7 +11,7 @@ pub enum Address {
     /// so the resulting address is `0b11{a2}{a1}{a0}`.
     Alternative { a2: bool, a1: bool, a0: bool },
     /// Custom address not directly supported by the device, but may be useful
-    /// when using I2c address translators.
+    /// when using I2C address translators.
     Custom(u8),
 }
 

--- a/embedded-devices/src/devices/mod.rs
+++ b/embedded-devices/src/devices/mod.rs
@@ -1,4 +1,5 @@
 pub mod analog_devices;
 pub mod bosch;
 pub mod microchip;
+pub mod sensirion;
 pub mod texas_instruments;

--- a/embedded-devices/src/devices/sensirion/mod.rs
+++ b/embedded-devices/src/devices/sensirion/mod.rs
@@ -1,0 +1,2 @@
+#[cfg(feature = "sensirion-scd4x")]
+pub mod scd4x;

--- a/embedded-devices/src/devices/sensirion/scd4x/address.rs
+++ b/embedded-devices/src/devices/sensirion/scd4x/address.rs
@@ -1,0 +1,21 @@
+use defmt::Format;
+
+const ADDRESS: u8 = 0x62;
+
+#[derive(Clone, Copy, PartialEq, Eq, Debug, Format)]
+pub enum Address {
+    /// default address
+    Default,
+    /// Custom address not directly supported by the device, but may be useful
+    /// when using I2c address translators.
+    Custom(u8),
+}
+
+impl From<Address> for u8 {
+    fn from(address: Address) -> Self {
+        match address {
+            Address::Default => ADDRESS,
+            Address::Custom(x) => x,
+        }
+    }
+}

--- a/embedded-devices/src/devices/sensirion/scd4x/address.rs
+++ b/embedded-devices/src/devices/sensirion/scd4x/address.rs
@@ -4,10 +4,10 @@ const ADDRESS: u8 = 0x62;
 
 #[derive(Clone, Copy, PartialEq, Eq, Debug, Format)]
 pub enum Address {
-    /// default address
+    /// Default address
     Default,
     /// Custom address not directly supported by the device, but may be useful
-    /// when using I2c address translators.
+    /// when using I2C address translators.
     Custom(u8),
 }
 

--- a/embedded-devices/src/devices/sensirion/scd4x/mod.rs
+++ b/embedded-devices/src/devices/sensirion/scd4x/mod.rs
@@ -1,25 +1,17 @@
-//! # SCD4X(SCD40/SCD41/SCD43)
-//! The SCD4x is Sensirion’s second generation optical CO2
-//! sensor. This sensor builds on the photoacoustic NDIR
-//! sensing principle and Sensirion’s patented PASens® and
-//! CMOSens® technology to offer high accuracy at an
-//! attractive price and small form factor. SMD assembly
-//! allows cost- and space-effective integration of the sensor
-//! combined with maximal freedom of design. On-chip
-//! signal compensation is realized with the built-in SHT4x
-//! humidity and temperature sensor.
+//! # SCD4x (SCD40/SCD41/SCD43)
+//!
+//! The SCD4x is Sensirion's second generation series of optical CO2 sensors. The sensor series
+//! builds on the photoacoustic NDIR sensing principle and Sensirion's patented PASens® and
+//! CMOSens® technology to offer accuracy at an attractive price and small form factor. SMD
+//! assembly allows cost- and space-effective integration of the sensor combined with maximal
+//! freedom of design. On-chip signal compensation is realized with the built-in SHT4x humidity and
+//! temperature sensor.
 //!
 //! Product Variants
-//! ▪ SCD40: Base accuracy, specified measurement
-//! range 400 –2’000 ppm
-//! ▪ SCD41: High accuracy, specified measurement
-//! range 400 – 5’000 ppm, compatible with
-//! California Title 241, RESET® 2 and WELL Building
-//! Standard™ 3, features single shot operation mode
-//! SCD43: High accuracy, specified measurement range
-//! 400 – 5’000 ppm, additionally compatible with
-//! ASHRAE Standard 62.1 4, features single-shot
-//! operation mode
+//! - **SCD40:** Base accuracy, specified range 400 – 2,000 ppm
+//! - **SCD41:** Improved accuracy, specified range 400 – 5,000 ppm, single shot operation feature
+//! - **SCD43:** High accuracy, specified range 400 – 5,000 ppm, comprehensive building standard compatibility, single shot operation feature
+//!
 //! ## Usage (sync)
 //!
 //! ```rust, only_if(sync)
@@ -67,7 +59,6 @@
 //! # Ok(())
 //! # }
 //! ```
-//!
 
 /// TODO: forced field calibration.
 use crc::{Algorithm, CRC_8_NRSC_5};
@@ -89,7 +80,7 @@ use uom::si::{
 pub mod address;
 pub mod registers;
 
-/// Enum describing the different modes the sensor can be in
+/// The different states the sensor can be in
 #[derive(Debug, defmt::Format, Default, PartialEq, Clone)]
 pub enum SensorState {
     #[default]
@@ -99,7 +90,7 @@ pub enum SensorState {
     Sleep,
 }
 
-/// Enum desrcribing which sensor variant we are dealing with
+/// The sensor variant we are dealing with
 #[derive(Default, PartialEq)]
 pub enum SensorVariant {
     #[default]
@@ -107,56 +98,6 @@ pub enum SensorVariant {
     SCD40,
     SCD41,
     SCD43,
-}
-
-#[device]
-#[maybe_async_cfg::maybe(
-    idents(hal(sync = "embedded_hal", async = "embedded_hal_async"), RegisterInterface),
-    sync(feature = "sync"),
-    async(feature = "async")
-)]
-pub struct SCD4x<I: embedded_registers::RegisterInterface> {
-    interface: I,
-    pub variant: SensorVariant,
-    /// The current state this sensor is in
-    /// You should use the `change_state`
-    /// for chaning states to prevent
-    /// a mismatch with the actual state
-    pub state: SensorState,
-}
-
-#[derive(Default)]
-pub struct SCD4xCrcCodec {}
-
-impl Crc8Algorithm for SCD4xCrcCodec {
-    fn new() -> &'static Algorithm<u8> {
-        const CUSTOM_ALG: crc::Algorithm<u8> = CRC_8_NRSC_5;
-        &CUSTOM_ALG
-    }
-}
-type SCD4xCodec = embedded_registers::i2c::codecs::Crc8Codec<2, 2, SCD4xCrcCodec>;
-
-#[maybe_async_cfg::maybe(
-    idents(hal(sync = "embedded_hal", async = "embedded_hal_async"), I2cDevice),
-    sync(feature = "sync"),
-    async(feature = "async")
-)]
-impl<I> SCD4x<embedded_registers::i2c::I2cDevice<I, hal::i2c::SevenBitAddress, SCD4xCodec>>
-where
-    I: hal::i2c::I2c<hal::i2c::SevenBitAddress> + hal::i2c::ErrorType,
-{
-    #[doc = "Initializes a new device with the given address on the specified bus."]
-    #[doc = "This consumes the I2C bus `I`."]
-    #[doc = ""]
-    #[doc = "Before using this device, you should call the [`Self::init`] method which ensures that the device is working correctly."]
-    #[inline]
-    pub fn new_i2c(interface: I, address: self::address::Address) -> Self {
-        Self {
-            interface: embedded_registers::i2c::I2cDevice::new(interface, address.into()),
-            variant: SensorVariant::default(),
-            state: SensorState::default(),
-        }
-    }
 }
 
 /// Measurement data
@@ -178,14 +119,65 @@ pub enum Error<BusError> {
     InvalidSensorVariant(u16),
     /// Trying to run a command which this sensor does not support
     /// e.g. measure_single_shot on SCD40
-    SensorVariantNotSupported(),
+    SensorVariantNotSupported,
     /// Sensor is in a status that does not allow the command you're trying to
     /// run or the command is not sensible for the current state
     InvalidSensorState(SensorState),
     /// The data is not ready yet.
     DataNotReady,
-    /// NVM data copy is still in progress.
-    NvmCopyInProgress,
+}
+
+#[derive(Default)]
+pub struct SCD4xCrcCodec {}
+
+impl Crc8Algorithm for SCD4xCrcCodec {
+    fn new() -> &'static Algorithm<u8> {
+        const CUSTOM_ALG: crc::Algorithm<u8> = CRC_8_NRSC_5;
+        &CUSTOM_ALG
+    }
+}
+type SCD4xCodec = embedded_registers::i2c::codecs::Crc8Codec<2, 2, SCD4xCrcCodec>;
+
+/// The SCD4x is Sensirion's second generation series of optical CO2 sensors. Several product variants
+/// exist with accuracy ranges from 400 – 2,000 ppm (SCD40) up to 400 – 5,000 ppm (SCD43).
+///
+/// For a full description and usage examples, refer to the [module documentation](self).
+#[device]
+#[maybe_async_cfg::maybe(
+    idents(hal(sync = "embedded_hal", async = "embedded_hal_async"), RegisterInterface),
+    sync(feature = "sync"),
+    async(feature = "async")
+)]
+pub struct SCD4x<I: embedded_registers::RegisterInterface> {
+    interface: I,
+    pub variant: SensorVariant,
+    /// The current state this sensor is in. Please use [`Self::change_state`] to enter a different
+    /// state, so the sensor state is known at all times.
+    pub state: SensorState,
+}
+
+#[maybe_async_cfg::maybe(
+    idents(hal(sync = "embedded_hal", async = "embedded_hal_async"), I2cDevice),
+    sync(feature = "sync"),
+    async(feature = "async")
+)]
+impl<I> SCD4x<embedded_registers::i2c::I2cDevice<I, hal::i2c::SevenBitAddress, SCD4xCodec>>
+where
+    I: hal::i2c::I2c<hal::i2c::SevenBitAddress> + hal::i2c::ErrorType,
+{
+    /// Initializes a new device with the given address on the specified bus.
+    /// This consumes the I2C bus `I`.
+    ///
+    /// Before using this device, you should call the [`Self::init`] method which
+    /// initializes the device and ensures that it is working correctly.
+    #[inline]
+    pub fn new_i2c(interface: I, address: self::address::Address) -> Self {
+        Self {
+            interface: embedded_registers::i2c::I2cDevice::new(interface, address.into()),
+            variant: SensorVariant::default(),
+            state: SensorState::default(),
+        }
+    }
 }
 
 #[device_impl]
@@ -195,29 +187,30 @@ pub enum Error<BusError> {
     async(feature = "async")
 )]
 impl<I: embedded_registers::RegisterInterface> SCD4x<I> {
-    /// Initialize the sensor by waiting for the boot-up period and verifying its device id.
-    /// The datasheet specifies a power-on-reset time of 30ms.
-    /// Calling this function is not mandatory, but recommended to ensure proper operation.
+    /// Initialize the sensor by waiting for the boot-up period and verifying its device id. The
+    /// datasheet specifies a power-on-reset time of 30ms. Calling this function is not mandatory,
+    /// but recommended to ensure proper operation.
     pub async fn init<D: hal::delay::DelayNs>(&mut self, delay: &mut D) -> Result<(), Error<I::Error>> {
         delay.delay_ms(30).await;
         let device_id = self.read_register::<GetSensorVariant>().await.map_err(Error::Bus)?;
-        if (device_id.read_variant() & 0xF000) != self::registers::SCD40_ID {
+        if (device_id.read_variant() & 0xF000) != self::registers::SENSOR_VARIANT_SCD40 {
             self.variant = SensorVariant::SCD40
-        } else if (device_id.read_variant() & 0xF000) != self::registers::SCD41_ID {
+        } else if (device_id.read_variant() & 0xF000) != self::registers::SENSOR_VARIANT_SCD41 {
             self.variant = SensorVariant::SCD41
-        } else if (device_id.read_variant() & 0xF000) != self::registers::SCD43_ID {
+        } else if (device_id.read_variant() & 0xF000) != self::registers::SENSOR_VARIANT_SCD43 {
             self.variant = SensorVariant::SCD43
         };
         if self.variant == SensorVariant::Unknown {
             return Err(Error::InvalidSensorVariant(device_id.read_variant()));
         }
 
+        // TODO: run "perform self test"?
         Ok(())
     }
 
-    /// Set the current sensor altitude is meters above the sea level
-    /// should be between 0 and 3000
-    /// Can only be set while in idle mode
+    /// Sets the current sensor altitude in meters above sea level. This value is used to derive an
+    /// expected air pressure value which will be used in signal compensation. Expects a value
+    /// between 0 and 3000 meters. This function must be called while the sensor is in idle mode.
     pub async fn set_sensor_altitude(&mut self, height: &mut Length) -> Result<(), Error<I::Error>> {
         if self.state != SensorState::Idle {
             return Err(Error::InvalidSensorState(self.state.clone()));
@@ -229,9 +222,9 @@ impl<I: embedded_registers::RegisterInterface> SCD4x<I> {
         Ok(())
     }
 
-    /// Set the sensor ambient pressure
-    /// should be between 70000 to 120000 Pa
-    /// Can only be set while in periodic measurement mode
+    /// Sets the ambient pressure which will be used for live signal compensation. A value between
+    /// 70,000 to 120,000 Pa is expected. This function must be called while the sensor is in
+    /// periodic measurement mode.
     pub async fn set_sensor_ambient_pressure(&mut self, height: &mut Pressure) -> Result<(), Error<I::Error>> {
         if self.state != SensorState::PeriodicMeasurement || self.state != SensorState::LowPowerPeriodicMeasurement {
             return Err(Error::InvalidSensorState(self.state.clone()));
@@ -243,12 +236,12 @@ impl<I: embedded_registers::RegisterInterface> SCD4x<I> {
         Ok(())
     }
 
-    /// Unconditionally try and get a measurement, returning an error if no data is
-    /// ready
+    /// Waits for the next measurement result and returns it.
+    /// TODO: this must wait for data ready! a measurement can only be read out
+    /// once, the buffer is cleared according to the datasheet
     async fn get_measurement(&mut self) -> Result<Measurements, Error<I::Error>> {
         let measurements = self.read_register::<ReadMeasurement>().await.map_err(Error::Bus)?;
-        let co2 = measurements.read_co2();
-        let co2 = Rational32::new_raw(co2 as i32, 1);
+        let co2 = Rational32::new_raw(measurements.read_co2() as i32, 1);
         let co2 = Ratio::new::<part_per_million>(co2);
         let temperature = Rational32::new_raw(175 * measurements.read_temperature() as i32, (1 << 16) - 1);
         let temperature = temperature - 45;
@@ -262,6 +255,16 @@ impl<I: embedded_registers::RegisterInterface> SCD4x<I> {
         })
     }
 
+    // TODO: implement function to reset the state by issuing wake up and
+    // stop_periodic_measurement.
+
+    /// Switch sensor state. This function will issue the correct command to switch from the
+    /// current sensor state to the desired state. The SCD4x series has no readout for the current
+    /// internal state, this function relies on knowing the current state. If the current state is
+    /// not known, please reset the sensor by issuing wake-up and stop-periodic-measurement
+    /// manually.
+    // TODO: ^------- implement force parameter to do that automatically? call reset_state or
+    // something.
     pub async fn change_state<D: hal::delay::DelayNs>(
         &mut self,
         delay: &mut D,
@@ -284,7 +287,7 @@ impl<I: embedded_registers::RegisterInterface> SCD4x<I> {
             }
             (SensorState::Idle, SensorState::Sleep) => {
                 if self.variant == SensorVariant::SCD40 {
-                    Err(Error::SensorVariantNotSupported())
+                    Err(Error::SensorVariantNotSupported)
                 } else {
                     self.write_register(PowerDown::default()).await.map_err(Error::Bus)?;
                     self.state = state;
@@ -312,7 +315,7 @@ impl<I: embedded_registers::RegisterInterface> SCD4x<I> {
             }
             (SensorState::PeriodicMeasurement, SensorState::Sleep) => {
                 if self.variant == SensorVariant::SCD40 {
-                    Err(Error::SensorVariantNotSupported())
+                    Err(Error::SensorVariantNotSupported)
                 } else {
                     self.write_register(StopPeriodicMeasurement::default())
                         .await
@@ -344,7 +347,7 @@ impl<I: embedded_registers::RegisterInterface> SCD4x<I> {
             }
             (SensorState::LowPowerPeriodicMeasurement, SensorState::Sleep) => {
                 if self.variant == SensorVariant::SCD40 {
-                    Err(Error::SensorVariantNotSupported())
+                    Err(Error::SensorVariantNotSupported)
                 } else {
                     self.write_register(StopPeriodicMeasurement::default())
                         .await
@@ -357,7 +360,7 @@ impl<I: embedded_registers::RegisterInterface> SCD4x<I> {
             }
             (SensorState::Sleep, SensorState::Idle) => {
                 if self.variant == SensorVariant::SCD40 {
-                    Err(Error::SensorVariantNotSupported())
+                    Err(Error::SensorVariantNotSupported)
                 } else {
                     self.write_register(WakeUp::default()).await.map_err(Error::Bus)?;
                     delay.delay_ms(30).await;
@@ -367,7 +370,7 @@ impl<I: embedded_registers::RegisterInterface> SCD4x<I> {
             }
             (SensorState::Sleep, SensorState::PeriodicMeasurement) => {
                 if self.variant == SensorVariant::SCD40 {
-                    Err(Error::SensorVariantNotSupported())
+                    Err(Error::SensorVariantNotSupported)
                 } else {
                     self.write_register(WakeUp::default()).await.map_err(Error::Bus)?;
                     delay.delay_ms(30).await;
@@ -380,7 +383,7 @@ impl<I: embedded_registers::RegisterInterface> SCD4x<I> {
             }
             (SensorState::Sleep, SensorState::LowPowerPeriodicMeasurement) => {
                 if self.variant == SensorVariant::SCD40 {
-                    Err(Error::SensorVariantNotSupported())
+                    Err(Error::SensorVariantNotSupported)
                 } else {
                     self.write_register(WakeUp::default()).await.map_err(Error::Bus)?;
                     delay.delay_ms(30).await;
@@ -395,11 +398,9 @@ impl<I: embedded_registers::RegisterInterface> SCD4x<I> {
         }
     }
 
-    // Performs a one-shot measurement. This will set the conversion mode to [`self::registers::ConversionMode::Oneshot´].
-    // which will cause the device to perform a single conversion a return to sleep mode afterwards.
-    //
-    // This function will initialize the measurement, wait until the data is acquired and return
-    // the temperature.
+    // Performs a one-shot measurement. If the sensor supports single shot measurements, we will
+    // utilize this, otherwise a single shot measurement is emulated by starting and stopping
+    // periodic measurement.
     pub async fn measure<D: hal::delay::DelayNs>(&mut self, delay: &mut D) -> Result<Measurements, Error<I::Error>> {
         match self.state {
             SensorState::Idle => match self.variant {
@@ -412,15 +413,17 @@ impl<I: embedded_registers::RegisterInterface> SCD4x<I> {
                 }
                 _ => {
                     self.change_state(delay, SensorState::PeriodicMeasurement).await?;
+                    // TODO: wait for data ready instead of 5000ms?
                     delay.delay_ms(5000).await;
-                    let erg = self.get_measurement().await;
+                    let ret = self.get_measurement().await;
                     self.change_state(delay, SensorState::Idle).await?;
-                    erg
+                    ret
                 }
             },
             SensorState::PeriodicMeasurement => {
                 let mut iteration = 0;
                 loop {
+                    // TODO: extract this into a function that waits for the next measurement?
                     let ready = self.read_register::<GetDataReadyStatus>().await.map_err(Error::Bus)?;
                     if (ready.read_status() & DATA_READY_MASK) != 0 {
                         return self.get_measurement().await;
@@ -445,18 +448,17 @@ impl<I: embedded_registers::RegisterInterface> SCD4x<I> {
                 }
             }
             SensorState::Sleep => {
-                // Sleep is only supported on the SCD41 or SCD43
-                // since both support single shot measurements we
-                // start one without further guards
+                // Sleep is only supported on the SCD41 or SCD43 since both support single shot
+                // measurements we start one without further guards
                 self.change_state(delay, SensorState::Idle).await?;
                 self.write_register(MeasureSingleShot::default())
                     .await
                     .map_err(Error::Bus)?;
                 delay.delay_ms(5000).await;
-                let erg = self.get_measurement().await;
+                let ret = self.get_measurement().await;
                 self.change_state(delay, SensorState::Idle).await?;
                 self.change_state(delay, SensorState::Sleep).await?;
-                erg
+                ret
             }
         }
     }

--- a/embedded-devices/src/devices/sensirion/scd4x/mod.rs
+++ b/embedded-devices/src/devices/sensirion/scd4x/mod.rs
@@ -1,0 +1,463 @@
+//! # SCD4X(SCD40/SCD41/SCD43)
+//! The SCD4x is Sensirion’s second generation optical CO2
+//! sensor. This sensor builds on the photoacoustic NDIR
+//! sensing principle and Sensirion’s patented PASens® and
+//! CMOSens® technology to offer high accuracy at an
+//! attractive price and small form factor. SMD assembly
+//! allows cost- and space-effective integration of the sensor
+//! combined with maximal freedom of design. On-chip
+//! signal compensation is realized with the built-in SHT4x
+//! humidity and temperature sensor.
+//!
+//! Product Variants
+//! ▪ SCD40: Base accuracy, specified measurement
+//! range 400 –2’000 ppm
+//! ▪ SCD41: High accuracy, specified measurement
+//! range 400 – 5’000 ppm, compatible with
+//! California Title 241, RESET® 2 and WELL Building
+//! Standard™ 3, features single shot operation mode
+//! SCD43: High accuracy, specified measurement range
+//! 400 – 5’000 ppm, additionally compatible with
+//! ASHRAE Standard 62.1 4, features single-shot
+//! operation mode
+//! ## Usage (sync)
+//!
+//! ```rust, only_if(sync)
+//! # fn test<I, D>(mut i2c: I, mut Delay: D) -> Result<(), embedded_devices::devices::sensirion::scd4x::Error<I::Error>>
+//! # where
+//! #   I: embedded_hal::i2c::I2c + embedded_hal::i2c::ErrorType,
+//! #   D: embedded_hal::delay::DelayNs
+//! # {
+//! use embedded_devices::devices::sensirion::scd4x::{SCD4xSync, address::Address};
+//! use uom::si::thermodynamic_temperature::degree_celsius;
+//! use uom::num_traits::ToPrimitive;
+//!
+//! // Create and initialize the device
+//! let mut scd = SCD4xSync::new_i2c(i2c, Address::Default);
+//! scd.init(&mut Delay).unwrap();
+//!
+//! // Read the current temperature in °C and convert it to a float
+//! let measurements = scd.measure(&mut Delay)?;
+//! let temp = measurements.temperature.get::<degree_celsius>().to_f32();
+//! println!("Current temperature: {:?}°C", temp);
+//! # Ok(())
+//! # }
+//! ```
+//!
+//! ## Usage (async)
+//!
+//! ```rust, only_if(async)
+//! # async fn test<I, D>(mut i2c: I, mut Delay: D) -> Result<(), embedded_devices::devices::sensirion::scd4x::Error<I::Error>>
+//! # where
+//! #   I: embedded_hal_async::i2c::I2c + embedded_hal_async::i2c::ErrorType,
+//! #   D: embedded_hal_async::delay::DelayNs
+//! # {
+//! use embedded_devices::devices::sensirion::scd4x::{SCD4xAsync, address::Address};
+//! use uom::si::thermodynamic_temperature::degree_celsius;
+//! use uom::num_traits::ToPrimitive;
+//!
+//! // Create and initialize the device
+//! let mut scd = SCD4xAsync::new_i2c(i2c, Address::Default);
+//! scd.init(&mut Delay).await.unwrap();
+//!
+//! // Read the current temperature in °C and convert it to a float
+//! let measurements = scd.measure(&mut Delay).await?;
+//! let temp = measurements.temperature.get::<degree_celsius>().to_f32();
+//! println!("Current temperature: {:?}°C", temp);
+//! # Ok(())
+//! # }
+//! ```
+//!
+
+/// TODO: forced field calibration.
+use crc::{Algorithm, CRC_8_NRSC_5};
+use embedded_devices_derive::{device, device_impl};
+use embedded_registers::i2c::codecs::Crc8Algorithm;
+use registers::{
+    AmbientPressure, GetDataReadyStatus, GetSensorVariant, MeasureSingleShot, PowerDown, ReadMeasurement,
+    SetSensorAltitude, StartLowPowerPeriodicMeasurement, StartPeriodicMeasurement, StopPeriodicMeasurement, WakeUp,
+    DATA_READY_MASK,
+};
+use uom::num_rational::Rational32;
+use uom::si::thermodynamic_temperature::degree_celsius;
+use uom::si::{
+    ratio::{part_per_million, percent},
+    rational32::{Ratio, ThermodynamicTemperature},
+    u16::{Length, Pressure},
+};
+
+pub mod address;
+pub mod registers;
+
+/// Enum describing the different modes the sensor can be in
+#[derive(Debug, defmt::Format, Default, PartialEq, Clone)]
+pub enum SensorState {
+    #[default]
+    Idle,
+    PeriodicMeasurement,
+    LowPowerPeriodicMeasurement,
+    Sleep,
+}
+
+/// Enum desrcribing which sensor variant we are dealing with
+#[derive(Default, PartialEq)]
+pub enum SensorVariant {
+    #[default]
+    Unknown,
+    SCD40,
+    SCD41,
+    SCD43,
+}
+
+#[device]
+#[maybe_async_cfg::maybe(
+    idents(hal(sync = "embedded_hal", async = "embedded_hal_async"), RegisterInterface),
+    sync(feature = "sync"),
+    async(feature = "async")
+)]
+pub struct SCD4x<I: embedded_registers::RegisterInterface> {
+    interface: I,
+    pub variant: SensorVariant,
+    /// The current state this sensor is in
+    /// You should use the `change_state`
+    /// for chaning states to prevent
+    /// a mismatch with the actual state
+    pub state: SensorState,
+}
+
+#[derive(Default)]
+pub struct SCD4xCrcCodec {}
+
+impl Crc8Algorithm for SCD4xCrcCodec {
+    fn new() -> &'static Algorithm<u8> {
+        const CUSTOM_ALG: crc::Algorithm<u8> = CRC_8_NRSC_5;
+        &CUSTOM_ALG
+    }
+}
+type SCD4xCodec = embedded_registers::i2c::codecs::Crc8Codec<2, 2, SCD4xCrcCodec>;
+
+#[maybe_async_cfg::maybe(
+    idents(hal(sync = "embedded_hal", async = "embedded_hal_async"), I2cDevice),
+    sync(feature = "sync"),
+    async(feature = "async")
+)]
+impl<I> SCD4x<embedded_registers::i2c::I2cDevice<I, hal::i2c::SevenBitAddress, SCD4xCodec>>
+where
+    I: hal::i2c::I2c<hal::i2c::SevenBitAddress> + hal::i2c::ErrorType,
+{
+    #[doc = "Initializes a new device with the given address on the specified bus."]
+    #[doc = "This consumes the I2C bus `I`."]
+    #[doc = ""]
+    #[doc = "Before using this device, you should call the [`Self::init`] method which ensures that the device is working correctly."]
+    #[inline]
+    pub fn new_i2c(interface: I, address: self::address::Address) -> Self {
+        Self {
+            interface: embedded_registers::i2c::I2cDevice::new(interface, address.into()),
+            variant: SensorVariant::default(),
+            state: SensorState::default(),
+        }
+    }
+}
+
+/// Measurement data
+#[derive(Debug)]
+pub struct Measurements {
+    pub co2: Ratio,
+    /// Current temperature
+    pub temperature: ThermodynamicTemperature,
+    /// Current relative humidity
+    pub humidity: Ratio,
+}
+
+/// All possible errors that may occur when using this device
+#[derive(Debug, defmt::Format)]
+pub enum Error<BusError> {
+    /// Bus error
+    Bus(BusError),
+    /// Invalid chip id was encountered in `init`
+    InvalidSensorVariant(u16),
+    /// Trying to run a command which this sensor does not support
+    /// e.g. measure_single_shot on SCD40
+    SensorVariantNotSupported(),
+    /// Sensor is in a status that does not allow the command you're trying to
+    /// run or the command is not sensible for the current state
+    InvalidSensorState(SensorState),
+    /// The data is not ready yet.
+    DataNotReady,
+    /// NVM data copy is still in progress.
+    NvmCopyInProgress,
+}
+
+#[device_impl]
+#[maybe_async_cfg::maybe(
+    idents(hal(sync = "embedded_hal", async = "embedded_hal_async"), RegisterInterface),
+    sync(feature = "sync"),
+    async(feature = "async")
+)]
+impl<I: embedded_registers::RegisterInterface> SCD4x<I> {
+    /// Initialize the sensor by waiting for the boot-up period and verifying its device id.
+    /// The datasheet specifies a power-on-reset time of 30ms.
+    /// Calling this function is not mandatory, but recommended to ensure proper operation.
+    pub async fn init<D: hal::delay::DelayNs>(&mut self, delay: &mut D) -> Result<(), Error<I::Error>> {
+        delay.delay_ms(30).await;
+        let device_id = self.read_register::<GetSensorVariant>().await.map_err(Error::Bus)?;
+        if (device_id.read_variant() & 0xF000) != self::registers::SCD40_ID {
+            self.variant = SensorVariant::SCD40
+        } else if (device_id.read_variant() & 0xF000) != self::registers::SCD41_ID {
+            self.variant = SensorVariant::SCD41
+        } else if (device_id.read_variant() & 0xF000) != self::registers::SCD43_ID {
+            self.variant = SensorVariant::SCD43
+        };
+        if self.variant == SensorVariant::Unknown {
+            return Err(Error::InvalidSensorVariant(device_id.read_variant()));
+        }
+
+        Ok(())
+    }
+
+    /// Set the current sensor altitude is meters above the sea level
+    /// should be between 0 and 3000
+    /// Can only be set while in idle mode
+    pub async fn set_sensor_altitude(&mut self, height: &mut Length) -> Result<(), Error<I::Error>> {
+        if self.state != SensorState::Idle {
+            return Err(Error::InvalidSensorState(self.state.clone()));
+        }
+        let height = height.get::<uom::si::length::meter>();
+        self.write_register(SetSensorAltitude::default().with_altitude(height))
+            .await
+            .map_err(Error::Bus)?;
+        Ok(())
+    }
+
+    /// Set the sensor ambient pressure
+    /// should be between 70000 to 120000 Pa
+    /// Can only be set while in periodic measurement mode
+    pub async fn set_sensor_ambient_pressure(&mut self, height: &mut Pressure) -> Result<(), Error<I::Error>> {
+        if self.state != SensorState::PeriodicMeasurement || self.state != SensorState::LowPowerPeriodicMeasurement {
+            return Err(Error::InvalidSensorState(self.state.clone()));
+        }
+        let pressure = height.get::<uom::si::pressure::hectopascal>();
+        self.write_register(AmbientPressure::default().with_pressure(pressure))
+            .await
+            .map_err(Error::Bus)?;
+        Ok(())
+    }
+
+    /// Unconditionally try and get a measurement, returning an error if no data is
+    /// ready
+    async fn get_measurement(&mut self) -> Result<Measurements, Error<I::Error>> {
+        let measurements = self.read_register::<ReadMeasurement>().await.map_err(Error::Bus)?;
+        let co2 = measurements.read_co2();
+        let co2 = Rational32::new_raw(co2 as i32, 1);
+        let co2 = Ratio::new::<part_per_million>(co2);
+        let temperature = Rational32::new_raw(175 * measurements.read_temperature() as i32, (1 << 16) - 1);
+        let temperature = temperature - 45;
+        let temperature = ThermodynamicTemperature::new::<degree_celsius>(temperature);
+        let humidity = Rational32::new_raw(100 * measurements.read_humidity() as i32, (1 << 16) - 1);
+        let humidity = Ratio::new::<percent>(humidity);
+        Ok(Measurements {
+            co2,
+            temperature,
+            humidity,
+        })
+    }
+
+    pub async fn change_state<D: hal::delay::DelayNs>(
+        &mut self,
+        delay: &mut D,
+        state: SensorState,
+    ) -> Result<(), Error<I::Error>> {
+        match (&self.state, &state) {
+            (SensorState::Idle, SensorState::PeriodicMeasurement) => {
+                self.write_register(StartPeriodicMeasurement::default())
+                    .await
+                    .map_err(Error::Bus)?;
+                self.state = state;
+                Ok(())
+            }
+            (SensorState::Idle, SensorState::LowPowerPeriodicMeasurement) => {
+                self.write_register(StartLowPowerPeriodicMeasurement::default())
+                    .await
+                    .map_err(Error::Bus)?;
+                self.state = state;
+                Ok(())
+            }
+            (SensorState::Idle, SensorState::Sleep) => {
+                if self.variant == SensorVariant::SCD40 {
+                    Err(Error::SensorVariantNotSupported())
+                } else {
+                    self.write_register(PowerDown::default()).await.map_err(Error::Bus)?;
+                    self.state = state;
+                    Ok(())
+                }
+            }
+            (SensorState::PeriodicMeasurement, SensorState::Idle) => {
+                self.write_register(StopPeriodicMeasurement::default())
+                    .await
+                    .map_err(Error::Bus)?;
+                delay.delay_ms(500).await;
+                self.state = state;
+                Ok(())
+            }
+            (SensorState::PeriodicMeasurement, SensorState::LowPowerPeriodicMeasurement) => {
+                self.write_register(StopPeriodicMeasurement::default())
+                    .await
+                    .map_err(Error::Bus)?;
+                delay.delay_ms(500).await;
+                self.write_register(StartLowPowerPeriodicMeasurement::default())
+                    .await
+                    .map_err(Error::Bus)?;
+                self.state = state;
+                Ok(())
+            }
+            (SensorState::PeriodicMeasurement, SensorState::Sleep) => {
+                if self.variant == SensorVariant::SCD40 {
+                    Err(Error::SensorVariantNotSupported())
+                } else {
+                    self.write_register(StopPeriodicMeasurement::default())
+                        .await
+                        .map_err(Error::Bus)?;
+                    delay.delay_ms(500).await;
+                    self.write_register(PowerDown::default()).await.map_err(Error::Bus)?;
+                    self.state = state;
+                    Ok(())
+                }
+            }
+            (SensorState::LowPowerPeriodicMeasurement, SensorState::Idle) => {
+                self.write_register(StopPeriodicMeasurement::default())
+                    .await
+                    .map_err(Error::Bus)?;
+                delay.delay_ms(500).await;
+                self.state = state;
+                Ok(())
+            }
+            (SensorState::LowPowerPeriodicMeasurement, SensorState::PeriodicMeasurement) => {
+                self.write_register(StopPeriodicMeasurement::default())
+                    .await
+                    .map_err(Error::Bus)?;
+                delay.delay_ms(500).await;
+                self.write_register(StartPeriodicMeasurement::default())
+                    .await
+                    .map_err(Error::Bus)?;
+                self.state = state;
+                Ok(())
+            }
+            (SensorState::LowPowerPeriodicMeasurement, SensorState::Sleep) => {
+                if self.variant == SensorVariant::SCD40 {
+                    Err(Error::SensorVariantNotSupported())
+                } else {
+                    self.write_register(StopPeriodicMeasurement::default())
+                        .await
+                        .map_err(Error::Bus)?;
+                    delay.delay_ms(500).await;
+                    self.write_register(PowerDown::default()).await.map_err(Error::Bus)?;
+                    self.state = state;
+                    Ok(())
+                }
+            }
+            (SensorState::Sleep, SensorState::Idle) => {
+                if self.variant == SensorVariant::SCD40 {
+                    Err(Error::SensorVariantNotSupported())
+                } else {
+                    self.write_register(WakeUp::default()).await.map_err(Error::Bus)?;
+                    delay.delay_ms(30).await;
+                    self.state = state;
+                    Ok(())
+                }
+            }
+            (SensorState::Sleep, SensorState::PeriodicMeasurement) => {
+                if self.variant == SensorVariant::SCD40 {
+                    Err(Error::SensorVariantNotSupported())
+                } else {
+                    self.write_register(WakeUp::default()).await.map_err(Error::Bus)?;
+                    delay.delay_ms(30).await;
+                    self.write_register(StartPeriodicMeasurement::default())
+                        .await
+                        .map_err(Error::Bus)?;
+                    self.state = state;
+                    Ok(())
+                }
+            }
+            (SensorState::Sleep, SensorState::LowPowerPeriodicMeasurement) => {
+                if self.variant == SensorVariant::SCD40 {
+                    Err(Error::SensorVariantNotSupported())
+                } else {
+                    self.write_register(WakeUp::default()).await.map_err(Error::Bus)?;
+                    delay.delay_ms(30).await;
+                    self.write_register(StartLowPowerPeriodicMeasurement::default())
+                        .await
+                        .map_err(Error::Bus)?;
+                    self.state = state;
+                    Ok(())
+                }
+            }
+            _ => Ok(()),
+        }
+    }
+
+    // Performs a one-shot measurement. This will set the conversion mode to [`self::registers::ConversionMode::Oneshot´].
+    // which will cause the device to perform a single conversion a return to sleep mode afterwards.
+    //
+    // This function will initialize the measurement, wait until the data is acquired and return
+    // the temperature.
+    pub async fn measure<D: hal::delay::DelayNs>(&mut self, delay: &mut D) -> Result<Measurements, Error<I::Error>> {
+        match self.state {
+            SensorState::Idle => match self.variant {
+                SensorVariant::SCD41 | SensorVariant::SCD43 => {
+                    self.write_register(MeasureSingleShot::default())
+                        .await
+                        .map_err(Error::Bus)?;
+                    delay.delay_ms(5000).await;
+                    self.get_measurement().await
+                }
+                _ => {
+                    self.change_state(delay, SensorState::PeriodicMeasurement).await?;
+                    delay.delay_ms(5000).await;
+                    let erg = self.get_measurement().await;
+                    self.change_state(delay, SensorState::Idle).await?;
+                    erg
+                }
+            },
+            SensorState::PeriodicMeasurement => {
+                let mut iteration = 0;
+                loop {
+                    let ready = self.read_register::<GetDataReadyStatus>().await.map_err(Error::Bus)?;
+                    if (ready.read_status() & DATA_READY_MASK) != 0 {
+                        return self.get_measurement().await;
+                    } else if iteration > (5000 / 1000) * 2 {
+                        return Err(Error::DataNotReady);
+                    }
+                    delay.delay_ms(1000).await;
+                    iteration += 1;
+                }
+            }
+            SensorState::LowPowerPeriodicMeasurement => {
+                let mut iteration = 0;
+                loop {
+                    let ready = self.read_register::<GetDataReadyStatus>().await.map_err(Error::Bus)?;
+                    if (ready.read_status() & DATA_READY_MASK) != 0 {
+                        return self.get_measurement().await;
+                    } else if iteration > (30000 / 2000) * 2 {
+                        return Err(Error::DataNotReady);
+                    }
+                    delay.delay_ms(2000).await;
+                    iteration += 1;
+                }
+            }
+            SensorState::Sleep => {
+                // Sleep is only supported on the SCD41 or SCD43
+                // since both support single shot measurements we
+                // start one without further guards
+                self.change_state(delay, SensorState::Idle).await?;
+                self.write_register(MeasureSingleShot::default())
+                    .await
+                    .map_err(Error::Bus)?;
+                delay.delay_ms(5000).await;
+                let erg = self.get_measurement().await;
+                self.change_state(delay, SensorState::Idle).await?;
+                self.change_state(delay, SensorState::Sleep).await?;
+                erg
+            }
+        }
+    }
+}

--- a/embedded-devices/src/devices/sensirion/scd4x/registers.rs
+++ b/embedded-devices/src/devices/sensirion/scd4x/registers.rs
@@ -1,0 +1,268 @@
+use embedded_devices_derive::device_register;
+use embedded_registers::register;
+
+/// Starts the periodic measurement mode. The signal update interval is 5 second
+#[device_register(super::SCD4x)]
+#[register(address = 0x21b1, mode = "w")]
+#[bondrewd(read_from = "msb0", default_endianness = "be", enforce_bytes = 0)]
+pub struct StartPeriodicMeasurement {}
+
+/// Starts the periodic measurement mode. The signal update interval is 5 second
+#[device_register(super::SCD4x)]
+#[register(address = 0x3f86, mode = "w")]
+#[bondrewd(read_from = "msb0", default_endianness = "be", enforce_bytes = 0)]
+pub struct StopPeriodicMeasurement {}
+
+/// reads the sensor output. The measurement data can only be read out once per signal update interval as the buffer
+/// is emptied upon read-out. If no data is available in the buffer, the sensor returns a NACK. To avoid a NACK response, the
+/// get_data_ready_status can be issued to check data status. The I2C master can abort the
+/// read transfer with a NACK followed by a STOP condition after any data byte if the user is not interested in subsequent data.
+#[device_register(super::SCD4x)]
+#[register(address = 0xec05, mode = "r")]
+#[bondrewd(read_from = "msb0", default_endianness = "be", enforce_bytes = 6)]
+pub struct ReadMeasurement {
+    pub co2: u16,
+    pub temperature: u16,
+    pub humidity: u16,
+}
+
+/// Setting the temperature offset of the SCD4x inside the customer device allows the user to optimize the RH and T
+/// output signal. The temperature offset can depend on several factors such as the SCD4x measurement mode, self-heating of
+/// close components, the ambient temperature and air flow. Thus, the SCD4x temperature offset should be determined after
+/// integration into the final device and under its typical operating conditions (including the operation mode to be used in the
+/// application) in thermal equilibrium. By default, the temperature offset is set to 4 °C. To save the setting to the EEPROM, the
+/// nersist_settings command may be issued. Equation below details how the characteristic temperature offset
+/// can be calculated using the current temperature output of the sensor (𝑇𝑆𝐶𝐷4𝑥), a reference temperature value (𝑇𝑅𝑒𝑓𝑒𝑟𝑒𝑛𝑐𝑒),
+/// and the previous temperature offset (𝑇𝑜𝑓𝑓𝑠𝑒𝑡_𝑝𝑟𝑒𝑣𝑖𝑜𝑢𝑠) obtained using the get_temperature_offset command.
+/// Recommended temperature offset values are between 0 °C and 20 °C.
+///
+/// 𝑇𝑜𝑓𝑓𝑠𝑒𝑡_𝑎𝑐𝑡𝑢𝑎𝑙 = 𝑇𝑆𝐶𝐷4𝑥 − 𝑇𝑅𝑒𝑓𝑒𝑟𝑒𝑛𝑐𝑒 + 𝑇𝑜𝑓𝑓𝑠𝑒𝑡_ 𝑝𝑟𝑒𝑣𝑖𝑜𝑢𝑠
+///
+#[device_register(super::SCD4x)]
+#[register(address = 0x241d, mode = "w")]
+#[bondrewd(read_from = "msb0", default_endianness = "be", enforce_bytes = 2)]
+pub struct SetTemperatureOffset {
+    pub offset: u16,
+}
+
+/// Get the current temperature offset value
+#[device_register(super::SCD4x)]
+#[register(address = 0x1218, mode = "r")]
+#[bondrewd(read_from = "msb0", default_endianness = "be", enforce_bytes = 2)]
+pub struct GetTemperatureOffset {
+    pub offset: u16,
+}
+
+/// Reading and writing the sensor altitude must be done while the SCD4x is in idle mode. Typically, the sensor
+/// altitude is set once after device installation. To save the setting to the EEPROM, the persist_settings
+/// command must be issued. The default sensor altitude value is set to 0 meters above sea level. Valid input values are between
+/// 0 – 3’000 m.
+#[device_register(super::SCD4x)]
+#[register(address = 0x2427, mode = "w")]
+#[bondrewd(read_from = "msb0", default_endianness = "be", enforce_bytes = 2)]
+pub struct SetSensorAltitude {
+    pub altitude: u16,
+}
+
+/// The get_sensor_altitude command can be sent while the SCD4x is in idle mode to read out the previously saved
+/// sensor altitude value set by the set_sensor_altitude command.
+#[device_register(super::SCD4x)]
+#[register(address = 0x2322, mode = "r")]
+#[bondrewd(read_from = "msb0", default_endianness = "be", enforce_bytes = 2)]
+pub struct GetSensorAltitude {
+    pub altitude: u16,
+}
+
+/// The set_ambient_pressure command can be sent during periodic measurements to enable continuous pressure
+/// compensation. Note that setting an ambient pressure overrides any pressure compensation based on a previously set sensor
+/// altitude. Use of this command is highly recommended for applications experiencing significant ambient pressure changes to
+/// ensure sensor accuracy. Valid input values are between 70’000 – 120’000 Pa. The default value is 101’300 Pa
+#[device_register(super::SCD4x)]
+#[register(address = 0xe000, mode = "rw")]
+#[bondrewd(read_from = "msb0", default_endianness = "be", enforce_bytes = 2)]
+pub struct AmbientPressure {
+    pub pressure: u16,
+}
+
+/// sets the current state (enabled / disabled) of the ASC. By default, ASC is enabled. To save the setting to the
+// EEPROM, the persist_settings command must be issued
+#[device_register(super::SCD4x)]
+#[register(address = 0x2416, mode = "w")]
+#[bondrewd(read_from = "msb0", default_endianness = "be", enforce_bytes = 2)]
+pub struct SetAutomaticSelfCalibrationEnabled {
+    #[bondrewd(bit_length = 15, reserve)]
+    #[allow(dead_code)]
+    pub reserved0: u16,
+    pub enabled: bool,
+}
+
+#[device_register(super::SCD4x)]
+#[register(address = 0x2313, mode = "r")]
+#[bondrewd(read_from = "msb0", default_endianness = "be", enforce_bytes = 2)]
+pub struct GetAutomaticSelfCalibrationEnabled {
+    #[bondrewd(bit_length = 15, reserve)]
+    #[allow(dead_code)]
+    pub reserved0: u16,
+    pub enabled: bool,
+}
+
+///sets the value of the ASC baseline target, i.e. the CO2 concentration in ppm which the ASC algorithm will assume
+/// as lower-bound background to which the SCD4x is exposed to regularly within one ASC period of operation. To save the setting
+/// to the EEPROM, the persist_settings command must be issued subsequently.
+#[device_register(super::SCD4x)]
+#[register(address = 0x243a, mode = "w")]
+#[bondrewd(read_from = "msb0", default_endianness = "be", enforce_bytes = 2)]
+pub struct SetAutomaticSelfCalibrationTarget {
+    pub target: u16,
+}
+#[device_register(super::SCD4x)]
+#[register(address = 0x233f, mode = "r")]
+#[bondrewd(read_from = "msb0", default_endianness = "be", enforce_bytes = 2)]
+pub struct GetAutomaticSelfCalibrationTarget {
+    pub target: u16,
+}
+
+/// starts the low power periodic measurement mode. The signal update interval is approximately 30 seconds.
+#[device_register(super::SCD4x)]
+#[register(address = 0x21ac, mode = "w")]
+#[bondrewd(read_from = "msb0", default_endianness = "be", enforce_bytes = 0)]
+pub struct StartLowPowerPeriodicMeasurement {}
+
+pub const DATA_READY_MASK: u16 = 0b11111111111;
+/// polls the sensor for whether data from a periodic or single shot measurement is ready to be read out
+#[device_register(super::SCD4x)]
+#[register(address = 0xe4b8, mode = "r")]
+#[bondrewd(read_from = "msb0", default_endianness = "be", enforce_bytes = 2)]
+pub struct GetDataReadyStatus {
+    pub status: u16,
+}
+
+/// Configuration settings such as the temperature offset, sensor altitude and the ASC enabled/disabled parameters
+/// are by default stored in the volatile memory (RAM) only. The persist_settings command stores the current configuration in the
+/// EEPROM of the SCD4x, ensuring the current settings persist after power-cycling. To avoid unnecessary wear of the EEPROM,
+/// the persist_settings command should only be sent following configuration changes whose persistence is required. The EEPROM
+/// is guaranteed to withstand at least 2000 write cycles. Note that field calibration history (i.e. FRC and ASC, see Section 3.8) is
+/// automatically stored in a separate EEPROM dimensioned for the specified sensor lifetime when operated continuously in either
+/// periodic measurement mode, low power periodic measurement mode (see Section 3.9) or single shot mode
+/// with 5 minute measurement interval.
+#[device_register(super::SCD4x)]
+#[register(address = 0x3615, mode = "w")]
+#[bondrewd(read_from = "msb0", default_endianness = "be", enforce_bytes = 0)]
+pub struct PersistSettings {}
+
+/// Reading out the serial number can be used to identify the chip and to verify the presence of the sensor.
+/// The get_serial_number command returns 3 words. Together, the 3 words
+/// constitute a unique serial number with a length of 48 bits (in big endian format).
+#[device_register(super::SCD4x)]
+#[register(address = 0x3682, mode = "w")]
+#[bondrewd(read_from = "msb0", default_endianness = "be", enforce_bytes = 6)]
+pub struct GetSerialNumber {
+    pub word1: u16,
+    pub word2: u16,
+    pub word3: u16,
+}
+
+/// The perform_self_test command can be used as an end-of-line test to check the sensor functionality.
+#[device_register(super::SCD4x)]
+#[register(address = 0x3639, mode = "r")]
+#[bondrewd(read_from = "msb0", default_endianness = "be", enforce_bytes = 2)]
+pub struct PerformSelfTest {
+    pub status: u16,
+}
+
+/// The perform_factory_reset command resets all configuration settings stored in the EEPROM and erases the
+/// FRC and ASC algorithm history
+#[device_register(super::SCD4x)]
+#[register(address = 0x3632, mode = "w")]
+#[bondrewd(read_from = "msb0", default_endianness = "be", enforce_bytes = 0)]
+pub struct PerformFactoryReset {}
+
+/// The reinit command reinitializes the sensor by reloading user settings from EEPROM. The sensor must be in the
+/// idle state before sending the reinit command. If the reinit command does not trigger the desired re-initialization, a power-cycle
+/// should be applied to the SCD4x.
+#[device_register(super::SCD4x)]
+#[register(address = 0x3646, mode = "w")]
+#[bondrewd(read_from = "msb0", default_endianness = "be", enforce_bytes = 0)]
+pub struct Reinit {}
+
+pub const SCD41_ID: u16 = 0x1000;
+pub const SCD40_ID: u16 = 0x0000;
+pub const SCD43_ID: u16 = 0x5000;
+
+/// reads out the SCD4x sensor variant (e.g. SCD40 or SCD41).
+#[device_register(super::SCD4x)]
+#[register(address = 0x202f, mode = "r")]
+#[bondrewd(read_from = "msb0", default_endianness = "be", enforce_bytes = 2)]
+pub struct GetSensorVariant {
+    pub variant: u16,
+}
+
+// The following features are only available on the SCD41
+
+/// On-demand measurement of CO2 concentration, relative humidity and temperature. The sensor output is read out
+/// by using the read_measurement command
+#[device_register(super::SCD4x)]
+#[register(address = 0x219d, mode = "w")]
+#[bondrewd(read_from = "msb0", default_endianness = "be", enforce_bytes = 0)]
+pub struct MeasureSingleShot {}
+
+/// on-demand measurement of relative humidity and temperature only, significantly reduces power consumption. The
+/// sensor output is read out by using the read_measurement command (Section 3.6.2). CO2 output is returned as 0 ppm
+#[device_register(super::SCD4x)]
+#[register(address = 0x2196, mode = "w")]
+#[bondrewd(read_from = "msb0", default_endianness = "be", enforce_bytes = 0)]
+pub struct MeasureSingleShotRHTOnly {}
+
+/// put the sensor from idle to sleep to reduce current consumption. Can be used to power down when operating the
+/// sensor in power-cycled single shot mode
+#[device_register(super::SCD4x)]
+#[register(address = 0x36e0, mode = "w")]
+#[bondrewd(read_from = "msb0", default_endianness = "be", enforce_bytes = 0)]
+pub struct PowerDown {}
+
+/// wake up the sensor from sleep mode into idle mode. Note that the SCD4x does not acknowledge the wake_up
+/// command. The sensor’s idle state after wake up can be verified by reading out the serial number.
+#[device_register(super::SCD4x)]
+#[register(address = 0x36f6, mode = "w")]
+#[bondrewd(read_from = "msb0", default_endianness = "be", enforce_bytes = 0)]
+pub struct WakeUp {}
+
+/// sets the duration of the initial period for ASC correction (in hours). By default, the initial period for ASC correction
+/// is 44 hours. Allowed values are integer multiples of 4 hours. A value of 0 results in an immediate correction. To save the setting
+/// to the EEPROM, the persist_settings (see Section 3.10.1) command must be issued.
+/// Note: For single shot operation, this parameter always assumes a measurement interval of 5 minutes, counting the number of
+/// single shots to calculate elapsed time. If single shot measurements are taken more / less frequently than once every 5 minutes,
+/// this parameter must be scaled accordingly to achieve the intended period in hours (e.g. for a 10-minute measurement interval,
+/// the scaled parameter value is obtained by multiplying the intended period in hours by 0.5).
+#[device_register(super::SCD4x)]
+#[register(address = 0x2445, mode = "w")]
+#[bondrewd(read_from = "msb0", default_endianness = "be", enforce_bytes = 2)]
+pub struct SetAutomaticSelfCalibrationInitialPeriod {
+    pub hours: u16,
+}
+#[device_register(super::SCD4x)]
+#[register(address = 0x2340, mode = "w")]
+#[bondrewd(read_from = "msb0", default_endianness = "be", enforce_bytes = 2)]
+pub struct GetAutomaticSelfCalibrationInitialPeriod {
+    pub hours: u16,
+}
+
+/// sets the standard period for ASC correction (in hours). By default, the standard period for ASC correction is 156
+/// hours. Allowed values are integer multiples of 4 hours. Note: a value of 0 results in an immediate correction. To save the
+/// setting to the EEPROM, the persist_settings (see Section 3.10.1) command must be issued.
+/// Note: For single shot operation, this parameter always assumes a measurement interval of 5 minutes, counting the number of
+/// single shots to calculate elapsed time. If single shot measurements are taken more / less frequently than once every 5 minutes,
+/// this parameter must be scaled accordingly to achieve the intended period in hours (e.g. for a 10-minute measurement interval,
+/// the scaled parameter value is obtained by multiplying the intended period in hours by 0.5).
+#[device_register(super::SCD4x)]
+#[register(address = 0x2445, mode = "w")]
+#[bondrewd(read_from = "msb0", default_endianness = "be", enforce_bytes = 2)]
+pub struct SetAutomaticSelfCalibrationStandardPeriod {
+    pub hours: u16,
+}
+#[device_register(super::SCD4x)]
+#[register(address = 0x2340, mode = "w")]
+#[bondrewd(read_from = "msb0", default_endianness = "be", enforce_bytes = 2)]
+pub struct GetAutomaticSelfCalibrationStandardPeriod {
+    pub hours: u16,
+}

--- a/embedded-devices/src/devices/sensirion/scd4x/registers.rs
+++ b/embedded-devices/src/devices/sensirion/scd4x/registers.rs
@@ -1,6 +1,12 @@
 use embedded_devices_derive::device_register;
 use embedded_registers::register;
 
+pub const SENSOR_VARIANT_SCD40: u16 = 0x0000;
+pub const SENSOR_VARIANT_SCD41: u16 = 0x1000;
+pub const SENSOR_VARIANT_SCD43: u16 = 0x5000;
+
+pub const DATA_READY_MASK: u16 = 0b11111111111;
+
 /// Starts the periodic measurement mode. The signal update interval is 5 second
 #[device_register(super::SCD4x)]
 #[register(address = 0x21b1, mode = "w")]
@@ -13,10 +19,11 @@ pub struct StartPeriodicMeasurement {}
 #[bondrewd(read_from = "msb0", default_endianness = "be", enforce_bytes = 0)]
 pub struct StopPeriodicMeasurement {}
 
-/// reads the sensor output. The measurement data can only be read out once per signal update interval as the buffer
-/// is emptied upon read-out. If no data is available in the buffer, the sensor returns a NACK. To avoid a NACK response, the
-/// get_data_ready_status can be issued to check data status. The I2C master can abort the
-/// read transfer with a NACK followed by a STOP condition after any data byte if the user is not interested in subsequent data.
+/// Reads the sensor output. The measurement data can only be read out once per signal update
+/// interval as the buffer is emptied upon read-out. If no data is available in the buffer, the
+/// sensor returns a NACK. To avoid a NACK response, the get_data_ready_status can be issued to
+/// check data status. The I2C master can abort the read transfer with a NACK followed by a STOP
+/// condition after any data byte if the user is not interested in subsequent data.
 #[device_register(super::SCD4x)]
 #[register(address = 0xec05, mode = "r")]
 #[bondrewd(read_from = "msb0", default_endianness = "be", enforce_bytes = 6)]
@@ -26,18 +33,15 @@ pub struct ReadMeasurement {
     pub humidity: u16,
 }
 
-/// Setting the temperature offset of the SCD4x inside the customer device allows the user to optimize the RH and T
-/// output signal. The temperature offset can depend on several factors such as the SCD4x measurement mode, self-heating of
-/// close components, the ambient temperature and air flow. Thus, the SCD4x temperature offset should be determined after
-/// integration into the final device and under its typical operating conditions (including the operation mode to be used in the
-/// application) in thermal equilibrium. By default, the temperature offset is set to 4 °C. To save the setting to the EEPROM, the
-/// nersist_settings command may be issued. Equation below details how the characteristic temperature offset
-/// can be calculated using the current temperature output of the sensor (𝑇𝑆𝐶𝐷4𝑥), a reference temperature value (𝑇𝑅𝑒𝑓𝑒𝑟𝑒𝑛𝑐𝑒),
-/// and the previous temperature offset (𝑇𝑜𝑓𝑓𝑠𝑒𝑡_𝑝𝑟𝑒𝑣𝑖𝑜𝑢𝑠) obtained using the get_temperature_offset command.
-/// Recommended temperature offset values are between 0 °C and 20 °C.
+/// Setting the temperature offset of the SCD4x inside the customer device allows the user to
+/// optimize the RH and T output signal. The temperature offset can depend on several factors such
+/// as the SCD4x measurement mode, self-heating of close components, the ambient temperature and
+/// air flow. Thus, the SCD4x temperature offset should be determined after integration into the
+/// final device and under its typical operating conditions (including the operation mode to be
+/// used in the application) in thermal equilibrium. By default, the temperature offset is set to 4
+/// °C. To save the setting to the EEPROM, the [`Self::PersistSettings`] command may be issued.
 ///
-/// 𝑇𝑜𝑓𝑓𝑠𝑒𝑡_𝑎𝑐𝑡𝑢𝑎𝑙 = 𝑇𝑆𝐶𝐷4𝑥 − 𝑇𝑅𝑒𝑓𝑒𝑟𝑒𝑛𝑐𝑒 + 𝑇𝑜𝑓𝑓𝑠𝑒𝑡_ 𝑝𝑟𝑒𝑣𝑖𝑜𝑢𝑠
-///
+/// Recommended temperature offset values are between 0°C and 20°C.
 #[device_register(super::SCD4x)]
 #[register(address = 0x241d, mode = "w")]
 #[bondrewd(read_from = "msb0", default_endianness = "be", enforce_bytes = 2)]
@@ -53,10 +57,10 @@ pub struct GetTemperatureOffset {
     pub offset: u16,
 }
 
-/// Reading and writing the sensor altitude must be done while the SCD4x is in idle mode. Typically, the sensor
-/// altitude is set once after device installation. To save the setting to the EEPROM, the persist_settings
-/// command must be issued. The default sensor altitude value is set to 0 meters above sea level. Valid input values are between
-/// 0 – 3’000 m.
+/// Reading and writing the sensor altitude must be done while the SCD4x is in idle mode.
+/// Typically, the sensor altitude is set once after device installation. To save the setting to
+/// the EEPROM, the persist_settings command must be issued. The default sensor altitude value is
+/// set to 0 meters above sea level. Valid input values are between 0 - 3,000 m.
 #[device_register(super::SCD4x)]
 #[register(address = 0x2427, mode = "w")]
 #[bondrewd(read_from = "msb0", default_endianness = "be", enforce_bytes = 2)]
@@ -64,8 +68,8 @@ pub struct SetSensorAltitude {
     pub altitude: u16,
 }
 
-/// The get_sensor_altitude command can be sent while the SCD4x is in idle mode to read out the previously saved
-/// sensor altitude value set by the set_sensor_altitude command.
+/// The get_sensor_altitude command can be sent while the SCD4x is in idle mode to read out the
+/// previously saved sensor altitude value set by the set_sensor_altitude command.
 #[device_register(super::SCD4x)]
 #[register(address = 0x2322, mode = "r")]
 #[bondrewd(read_from = "msb0", default_endianness = "be", enforce_bytes = 2)]
@@ -73,19 +77,21 @@ pub struct GetSensorAltitude {
     pub altitude: u16,
 }
 
-/// The set_ambient_pressure command can be sent during periodic measurements to enable continuous pressure
-/// compensation. Note that setting an ambient pressure overrides any pressure compensation based on a previously set sensor
-/// altitude. Use of this command is highly recommended for applications experiencing significant ambient pressure changes to
-/// ensure sensor accuracy. Valid input values are between 70’000 – 120’000 Pa. The default value is 101’300 Pa
+/// The set_ambient_pressure command can be sent during periodic measurements to enable continuous
+/// pressure compensation. Note that setting an ambient pressure overrides any pressure
+/// compensation based on a previously set sensor altitude. Use of this command is highly
+/// recommended for applications experiencing significant ambient pressure changes to ensure sensor
+/// accuracy. Valid input values are between 70,000 - 120,000 Pa. The default value is 101,300 Pa.
 #[device_register(super::SCD4x)]
 #[register(address = 0xe000, mode = "rw")]
 #[bondrewd(read_from = "msb0", default_endianness = "be", enforce_bytes = 2)]
 pub struct AmbientPressure {
+    #[register(default = 101300)]
     pub pressure: u16,
 }
 
-/// sets the current state (enabled / disabled) of the ASC. By default, ASC is enabled. To save the setting to the
-// EEPROM, the persist_settings command must be issued
+/// Sets the current state of the ASC. By default, ASC is enabled. To save the setting to the
+/// EEPROM, the persist_settings command must be issued.
 #[device_register(super::SCD4x)]
 #[register(address = 0x2416, mode = "w")]
 #[bondrewd(read_from = "msb0", default_endianness = "be", enforce_bytes = 2)]
@@ -93,9 +99,11 @@ pub struct SetAutomaticSelfCalibrationEnabled {
     #[bondrewd(bit_length = 15, reserve)]
     #[allow(dead_code)]
     pub reserved0: u16,
+    #[register(default = true)]
     pub enabled: bool,
 }
 
+/// Gets the current ASC state
 #[device_register(super::SCD4x)]
 #[register(address = 0x2313, mode = "r")]
 #[bondrewd(read_from = "msb0", default_endianness = "be", enforce_bytes = 2)]
@@ -103,18 +111,21 @@ pub struct GetAutomaticSelfCalibrationEnabled {
     #[bondrewd(bit_length = 15, reserve)]
     #[allow(dead_code)]
     pub reserved0: u16,
+    #[register(default = true)]
     pub enabled: bool,
 }
 
-///sets the value of the ASC baseline target, i.e. the CO2 concentration in ppm which the ASC algorithm will assume
-/// as lower-bound background to which the SCD4x is exposed to regularly within one ASC period of operation. To save the setting
-/// to the EEPROM, the persist_settings command must be issued subsequently.
+/// Sets the value of the ASC baseline target, i.e. the CO2 concentration in ppm which the ASC
+/// algorithm will assume as lower-bound background to which the SCD4x is exposed to regularly
+/// within one ASC period of operation. To save the setting to the EEPROM, the persist_settings
+/// command must be issued subsequently.
 #[device_register(super::SCD4x)]
 #[register(address = 0x243a, mode = "w")]
 #[bondrewd(read_from = "msb0", default_endianness = "be", enforce_bytes = 2)]
 pub struct SetAutomaticSelfCalibrationTarget {
     pub target: u16,
 }
+
 #[device_register(super::SCD4x)]
 #[register(address = 0x233f, mode = "r")]
 #[bondrewd(read_from = "msb0", default_endianness = "be", enforce_bytes = 2)]
@@ -122,14 +133,13 @@ pub struct GetAutomaticSelfCalibrationTarget {
     pub target: u16,
 }
 
-/// starts the low power periodic measurement mode. The signal update interval is approximately 30 seconds.
+/// Starts the low power periodic measurement mode. The signal update interval is approximately 30 seconds.
 #[device_register(super::SCD4x)]
 #[register(address = 0x21ac, mode = "w")]
 #[bondrewd(read_from = "msb0", default_endianness = "be", enforce_bytes = 0)]
 pub struct StartLowPowerPeriodicMeasurement {}
 
-pub const DATA_READY_MASK: u16 = 0b11111111111;
-/// polls the sensor for whether data from a periodic or single shot measurement is ready to be read out
+/// Polls the sensor for whether data from a periodic or single shot measurement is ready to be read out
 #[device_register(super::SCD4x)]
 #[register(address = 0xe4b8, mode = "r")]
 #[bondrewd(read_from = "msb0", default_endianness = "be", enforce_bytes = 2)]
@@ -137,32 +147,33 @@ pub struct GetDataReadyStatus {
     pub status: u16,
 }
 
-/// Configuration settings such as the temperature offset, sensor altitude and the ASC enabled/disabled parameters
-/// are by default stored in the volatile memory (RAM) only. The persist_settings command stores the current configuration in the
-/// EEPROM of the SCD4x, ensuring the current settings persist after power-cycling. To avoid unnecessary wear of the EEPROM,
-/// the persist_settings command should only be sent following configuration changes whose persistence is required. The EEPROM
-/// is guaranteed to withstand at least 2000 write cycles. Note that field calibration history (i.e. FRC and ASC, see Section 3.8) is
-/// automatically stored in a separate EEPROM dimensioned for the specified sensor lifetime when operated continuously in either
-/// periodic measurement mode, low power periodic measurement mode (see Section 3.9) or single shot mode
-/// with 5 minute measurement interval.
+/// Configuration settings such as the temperature offset, sensor altitude and the ASC
+/// enabled/disabled parameters are by default stored in the volatile memory (RAM) only. The
+/// persist_settings command stores the current configuration in the EEPROM of the SCD4x, ensuring
+/// the current settings persist after power-cycling. To avoid unnecessary wear of the EEPROM, the
+/// persist_settings command should only be sent following configuration changes whose persistence
+/// is required. The EEPROM is guaranteed to withstand at least 2000 write cycles. Note that field
+/// calibration history (i.e. FRC and ASC, see Section 3.8) is automatically stored in a separate
+/// EEPROM dimensioned for the specified sensor lifetime when operated continuously in either
+/// periodic measurement mode, low power periodic measurement mode (see Section 3.9) or single shot
+/// mode with 5 minute measurement interval.
 #[device_register(super::SCD4x)]
 #[register(address = 0x3615, mode = "w")]
 #[bondrewd(read_from = "msb0", default_endianness = "be", enforce_bytes = 0)]
 pub struct PersistSettings {}
 
-/// Reading out the serial number can be used to identify the chip and to verify the presence of the sensor.
-/// The get_serial_number command returns 3 words. Together, the 3 words
-/// constitute a unique serial number with a length of 48 bits (in big endian format).
+/// Reading out the serial number can be used to identify the chip and to verify the presence of
+/// the sensor.
 #[device_register(super::SCD4x)]
 #[register(address = 0x3682, mode = "w")]
 #[bondrewd(read_from = "msb0", default_endianness = "be", enforce_bytes = 6)]
 pub struct GetSerialNumber {
-    pub word1: u16,
-    pub word2: u16,
-    pub word3: u16,
+    #[bondrewd(bit_length = 48)]
+    pub serial_number: u16,
 }
 
-/// The perform_self_test command can be used as an end-of-line test to check the sensor functionality.
+/// The perform_self_test command can be used as an end-of-line test to check the sensor
+/// functionality.
 #[device_register(super::SCD4x)]
 #[register(address = 0x3639, mode = "r")]
 #[bondrewd(read_from = "msb0", default_endianness = "be", enforce_bytes = 2)]
@@ -170,24 +181,20 @@ pub struct PerformSelfTest {
     pub status: u16,
 }
 
-/// The perform_factory_reset command resets all configuration settings stored in the EEPROM and erases the
-/// FRC and ASC algorithm history
+/// The perform_factory_reset command resets all configuration settings stored in the EEPROM and
+/// erases the FRC and ASC algorithm history
 #[device_register(super::SCD4x)]
 #[register(address = 0x3632, mode = "w")]
 #[bondrewd(read_from = "msb0", default_endianness = "be", enforce_bytes = 0)]
 pub struct PerformFactoryReset {}
 
-/// The reinit command reinitializes the sensor by reloading user settings from EEPROM. The sensor must be in the
-/// idle state before sending the reinit command. If the reinit command does not trigger the desired re-initialization, a power-cycle
-/// should be applied to the SCD4x.
+/// The reinit command reinitializes the sensor by reloading user settings from EEPROM. The sensor
+/// must be in the idle state before sending the reinit command. If the reinit command does not
+/// trigger the desired re-initialization, a power-cycle should be applied to the SCD4x.
 #[device_register(super::SCD4x)]
 #[register(address = 0x3646, mode = "w")]
 #[bondrewd(read_from = "msb0", default_endianness = "be", enforce_bytes = 0)]
 pub struct Reinit {}
-
-pub const SCD41_ID: u16 = 0x1000;
-pub const SCD40_ID: u16 = 0x0000;
-pub const SCD43_ID: u16 = 0x5000;
 
 /// reads out the SCD4x sensor variant (e.g. SCD40 or SCD41).
 #[device_register(super::SCD4x)]
@@ -206,63 +213,75 @@ pub struct GetSensorVariant {
 #[bondrewd(read_from = "msb0", default_endianness = "be", enforce_bytes = 0)]
 pub struct MeasureSingleShot {}
 
-/// on-demand measurement of relative humidity and temperature only, significantly reduces power consumption. The
-/// sensor output is read out by using the read_measurement command (Section 3.6.2). CO2 output is returned as 0 ppm
+/// On-demand measurement of relative humidity and temperature only, significantly reduces power
+/// consumption. The sensor output is read out by using the read_measurement command (Section
+/// 3.6.2). CO2 output is returned as 0 ppm
 #[device_register(super::SCD4x)]
 #[register(address = 0x2196, mode = "w")]
 #[bondrewd(read_from = "msb0", default_endianness = "be", enforce_bytes = 0)]
 pub struct MeasureSingleShotRHTOnly {}
 
-/// put the sensor from idle to sleep to reduce current consumption. Can be used to power down when operating the
-/// sensor in power-cycled single shot mode
+/// Put the sensor from idle to sleep to reduce current consumption. Can be used to power down when
+/// operating the sensor in power-cycled single shot mode
 #[device_register(super::SCD4x)]
 #[register(address = 0x36e0, mode = "w")]
 #[bondrewd(read_from = "msb0", default_endianness = "be", enforce_bytes = 0)]
 pub struct PowerDown {}
 
-/// wake up the sensor from sleep mode into idle mode. Note that the SCD4x does not acknowledge the wake_up
-/// command. The sensor’s idle state after wake up can be verified by reading out the serial number.
+/// Wake up the sensor from sleep mode into idle mode. Note that the SCD4x does not acknowledge the
+/// wake_up command. The sensor's idle state after wake up can be verified by reading out the
+/// serial number.
 #[device_register(super::SCD4x)]
 #[register(address = 0x36f6, mode = "w")]
 #[bondrewd(read_from = "msb0", default_endianness = "be", enforce_bytes = 0)]
 pub struct WakeUp {}
 
-/// sets the duration of the initial period for ASC correction (in hours). By default, the initial period for ASC correction
-/// is 44 hours. Allowed values are integer multiples of 4 hours. A value of 0 results in an immediate correction. To save the setting
-/// to the EEPROM, the persist_settings (see Section 3.10.1) command must be issued.
-/// Note: For single shot operation, this parameter always assumes a measurement interval of 5 minutes, counting the number of
-/// single shots to calculate elapsed time. If single shot measurements are taken more / less frequently than once every 5 minutes,
-/// this parameter must be scaled accordingly to achieve the intended period in hours (e.g. for a 10-minute measurement interval,
-/// the scaled parameter value is obtained by multiplying the intended period in hours by 0.5).
+/// Sets the duration of the initial period for ASC correction (in hours). By default, the initial
+/// period for ASC correction is 44 hours. Allowed values are integer multiples of 4 hours. A value
+/// of 0 results in an immediate correction. To save the setting to the EEPROM, the
+/// persist_settings (see Section 3.10.1) command must be issued. Note: For single shot operation,
+/// this parameter always assumes a measurement interval of 5 minutes, counting the number of
+/// single shots to calculate elapsed time. If single shot measurements are taken more / less
+/// frequently than once every 5 minutes, this parameter must be scaled accordingly to achieve the
+/// intended period in hours (e.g. for a 10-minute measurement interval, the scaled parameter value
+/// is obtained by multiplying the intended period in hours by 0.5).
 #[device_register(super::SCD4x)]
 #[register(address = 0x2445, mode = "w")]
 #[bondrewd(read_from = "msb0", default_endianness = "be", enforce_bytes = 2)]
 pub struct SetAutomaticSelfCalibrationInitialPeriod {
+    #[register(default = 76)]
     pub hours: u16,
 }
+
 #[device_register(super::SCD4x)]
 #[register(address = 0x2340, mode = "w")]
 #[bondrewd(read_from = "msb0", default_endianness = "be", enforce_bytes = 2)]
 pub struct GetAutomaticSelfCalibrationInitialPeriod {
+    #[register(default = 76)]
     pub hours: u16,
 }
 
-/// sets the standard period for ASC correction (in hours). By default, the standard period for ASC correction is 156
-/// hours. Allowed values are integer multiples of 4 hours. Note: a value of 0 results in an immediate correction. To save the
-/// setting to the EEPROM, the persist_settings (see Section 3.10.1) command must be issued.
-/// Note: For single shot operation, this parameter always assumes a measurement interval of 5 minutes, counting the number of
-/// single shots to calculate elapsed time. If single shot measurements are taken more / less frequently than once every 5 minutes,
-/// this parameter must be scaled accordingly to achieve the intended period in hours (e.g. for a 10-minute measurement interval,
-/// the scaled parameter value is obtained by multiplying the intended period in hours by 0.5).
+/// Sets the standard period for ASC correction (in hours). By default, the standard period for ASC
+/// correction is 156 hours. Allowed values are integer multiples of 4 hours. Note: a value of 0
+/// results in an immediate correction. To save the setting to the EEPROM, the persist_settings
+/// (see Section 3.10.1) command must be issued. Note: For single shot operation, this parameter
+/// always assumes a measurement interval of 5 minutes, counting the number of single shots to
+/// calculate elapsed time. If single shot measurements are taken more / less frequently than once
+/// every 5 minutes, this parameter must be scaled accordingly to achieve the intended period in
+/// hours (e.g. for a 10-minute measurement interval, the scaled parameter value is obtained by
+/// multiplying the intended period in hours by 0.5).
 #[device_register(super::SCD4x)]
 #[register(address = 0x2445, mode = "w")]
 #[bondrewd(read_from = "msb0", default_endianness = "be", enforce_bytes = 2)]
 pub struct SetAutomaticSelfCalibrationStandardPeriod {
+    #[register(default = 156)]
     pub hours: u16,
 }
+
 #[device_register(super::SCD4x)]
 #[register(address = 0x2340, mode = "w")]
 #[bondrewd(read_from = "msb0", default_endianness = "be", enforce_bytes = 2)]
 pub struct GetAutomaticSelfCalibrationStandardPeriod {
+    #[register(default = 156)]
     pub hours: u16,
 }

--- a/embedded-devices/src/devices/sensirion/scd4x/registers.rs
+++ b/embedded-devices/src/devices/sensirion/scd4x/registers.rs
@@ -86,7 +86,7 @@ pub struct GetSensorAltitude {
 #[register(address = 0xe000, mode = "rw")]
 #[bondrewd(read_from = "msb0", default_endianness = "be", enforce_bytes = 2)]
 pub struct AmbientPressure {
-    #[register(default = 101300)]
+    #[register(default = 1013)]
     pub pressure: u16,
 }
 
@@ -165,11 +165,11 @@ pub struct PersistSettings {}
 /// Reading out the serial number can be used to identify the chip and to verify the presence of
 /// the sensor.
 #[device_register(super::SCD4x)]
-#[register(address = 0x3682, mode = "w")]
+#[register(address = 0x3682, mode = "r")]
 #[bondrewd(read_from = "msb0", default_endianness = "be", enforce_bytes = 6)]
 pub struct GetSerialNumber {
     #[bondrewd(bit_length = 48)]
-    pub serial_number: u16,
+    pub serial_number: u64,
 }
 
 /// The perform_self_test command can be used as an end-of-line test to check the sensor
@@ -178,7 +178,10 @@ pub struct GetSerialNumber {
 #[register(address = 0x3639, mode = "r")]
 #[bondrewd(read_from = "msb0", default_endianness = "be", enforce_bytes = 2)]
 pub struct PerformSelfTest {
-    pub status: u16,
+    pub status: u8,
+    #[bondrewd(reserve)]
+    #[allow(dead_code)]
+    pub reserved0: u8,
 }
 
 /// The perform_factory_reset command resets all configuration settings stored in the EEPROM and

--- a/embedded-devices/src/devices/texas_instruments/ina219/address.rs
+++ b/embedded-devices/src/devices/texas_instruments/ina219/address.rs
@@ -34,7 +34,7 @@ pub enum Address {
     /// Address selection pins A0 and A1 tied to specific pins
     A0A1(Pin, Pin),
     /// Custom address not directly supported by the device, but may be useful
-    /// when using I2c address translators.
+    /// when using I2C address translators.
     Custom(u8),
 }
 

--- a/embedded-devices/src/devices/texas_instruments/ina228/address.rs
+++ b/embedded-devices/src/devices/texas_instruments/ina228/address.rs
@@ -34,7 +34,7 @@ pub enum Address {
     /// Address selection pins A0 and A1 tied to specific pins
     A0A1(Pin, Pin),
     /// Custom address not directly supported by the device, but may be useful
-    /// when using I2c address translators.
+    /// when using I2C address translators.
     Custom(u8),
 }
 

--- a/embedded-devices/src/devices/texas_instruments/tmp102/address.rs
+++ b/embedded-devices/src/devices/texas_instruments/tmp102/address.rs
@@ -16,7 +16,7 @@ pub enum Address {
     /// Address selection pin connected to SCL
     Scl,
     /// Custom address not directly supported by the device, but may be useful
-    /// when using I2c address translators.
+    /// when using I2C address translators.
     Custom(u8),
 }
 

--- a/embedded-devices/src/devices/texas_instruments/tmp117/address.rs
+++ b/embedded-devices/src/devices/texas_instruments/tmp117/address.rs
@@ -16,7 +16,7 @@ pub enum Address {
     /// Address selection pin connected to SCL
     Scl,
     /// Custom address not directly supported by the device, but may be useful
-    /// when using I2c address translators.
+    /// when using I2C address translators.
     Custom(u8),
 }
 

--- a/embedded-devices/src/simple_device.rs
+++ b/embedded-devices/src/simple_device.rs
@@ -31,7 +31,7 @@ macro_rules! i2c {
                     interface: embedded_registers::i2c::I2cDevice::new(
                         interface,
                         address.into()
-                    )
+                    ),
                 }
             }
         }

--- a/embedded-registers/Cargo.toml
+++ b/embedded-registers/Cargo.toml
@@ -12,6 +12,7 @@ categories.workspace = true
 license.workspace = true
 
 [dependencies]
+arrayvec = { version = "0.7.6", default-features = false }
 bondrewd = { version = "0.1.14", default-features = false, features = ["derive"] }
 bytemuck = { version = "1.22.0", features = ["derive", "min_const_generics"] }
 crc = "3.2.1"

--- a/embedded-registers/Cargo.toml
+++ b/embedded-registers/Cargo.toml
@@ -14,6 +14,7 @@ license.workspace = true
 [dependencies]
 bondrewd = { version = "0.1.14", default-features = false, features = ["derive"] }
 bytemuck = { version = "1.22.0", features = ["derive", "min_const_generics"] }
+crc = "3.2.1"
 defmt = "1.0.1"
 embedded-hal = "1.0.0"
 embedded-hal-async = { version = "1.0.0", optional = true }

--- a/embedded-registers/src/i2c/codecs/crc_codec.rs
+++ b/embedded-registers/src/i2c/codecs/crc_codec.rs
@@ -1,49 +1,50 @@
 use core::marker::PhantomData;
 
 use crate::{ReadableRegister, WritableRegister};
+use arrayvec::ArrayVec;
 use bytemuck::Zeroable;
 use crc::{Algorithm, CRC_8_NRSC_5};
 
-/// This codec represents the most commonly found codecs for I2C devices.
-/// The main variable is the size of register addresses in bytes.
+/// This codec implements an I2C codec utilizing crc checksums for data
+/// The main variables are:
+/// - the size of register addresses in bytes.
+/// - the crc algorithm in use
+/// - set chunk size that get checksummed
 ///
-/// This codec has no information over register sizes or the existence of
-/// read/write address-auto-increment which some devices support.
+/// This implements the codec only for crc outputs of single byte size.
+/// If your device has larger crc sums, you cannot use this implementation as is.
+///
+/// This codec has no information over register sizes or contents.
 /// It will always send one header and then receive/send the associated register data,
-/// so it's compatible with auto-increment usage, but cannot be used to read or write
-/// registers that require interspersing the address between bytes.
-///
-/// Devices often use a mixed mode, where some registers allow auto-increment while others
-/// don't, or where the address is directly associated with a specific, but varying, register size.
-/// Therefore, it is up to the user to make sure that accessing a register via this codec
-/// is supported by the hardware.
+/// interspersed with crc sums each CHUNK_SIZE bytes.
+/// This makes the codec unsuited for cases where the device has
+/// registers that require interspersing the crc between fields of differing sizes.
 ///
 /// The following generic parameters are available:
 ///
 /// | Parameter | Type | Description |
 /// |---|---|---|
 /// | `HEADER_SIZE` | `usize` | The size of the command header (register address) in bytes |
+/// | `CHUNK_SIZE` | `usize` | The size of a chunk that has a singular crc sum attached in bytes |
+/// | `C` | `Crc8Algorithm` | A static reference to the crc algorithm to be used |
+/// Example implemenation for a basic CRC Algorithm:
+/// #[derive(Default)]
+/// struct MyCrc {}
+///
+/// impl Crc8Algorithm for MyCrc {
+///     fn new() -> &'static Algorithm<u8> {
+///         const CUSTOM_ALG: crc::Algorithm<u8> = CRC_8_NRSC_5;
+///         &CUSTOM_ALG
+///     }
+/// }
 #[derive(Default)]
-pub struct Crc8Codec<const HEADER_SIZE: usize, C: Crc8Algorithm> {
+pub struct Crc8Codec<const HEADER_SIZE: usize, const CHUNK_SIZE: usize, C: Crc8Algorithm> {
     _algo: PhantomData<C>,
 }
 
 pub trait Crc8Algorithm: Default {
+    /// Return reference to global static CRC Algorithm
     fn new() -> &'static Algorithm<u8>;
-    fn generate(bytes: &[u8]) -> u8 {
-        let crc = crc::Crc::<u8>::new(Self::new());
-        crc.checksum(bytes)
-    }
-}
-
-#[derive(Default)]
-struct MyCrc {}
-
-impl Crc8Algorithm for MyCrc {
-    fn new() -> &'static Algorithm<u8> {
-        const CUSTOM_ALG: crc::Algorithm<u8> = CRC_8_NRSC_5;
-        &CUSTOM_ALG
-    }
 }
 
 #[maybe_async_cfg::maybe(
@@ -52,7 +53,9 @@ impl Crc8Algorithm for MyCrc {
     async(feature = "async"),
     keep_self
 )]
-impl<const HEADER_SIZE: usize, C: Crc8Algorithm + 'static> crate::i2c::Codec for Crc8Codec<HEADER_SIZE, C> {
+impl<const HEADER_SIZE: usize, const CHUNK_SIZE: usize, C: Crc8Algorithm + 'static> crate::i2c::Codec
+    for Crc8Codec<HEADER_SIZE, CHUNK_SIZE, C>
+{
     #[inline]
     async fn read_register<R, I, A>(bound_bus: &mut crate::i2c::I2cBoundBus<I, A>) -> Result<R, I::Error>
     where
@@ -60,25 +63,32 @@ impl<const HEADER_SIZE: usize, C: Crc8Algorithm + 'static> crate::i2c::Codec for
         I: hal::i2c::I2c<A> + hal::i2c::ErrorType,
         A: hal::i2c::AddressMode + Copy,
     {
+        let crc = crc::Crc::<u8>::new(C::new());
         let header = &R::ADDRESS.to_be_bytes()[core::mem::size_of_val(&R::ADDRESS) - HEADER_SIZE..];
 
-        #[repr(C, packed(1))]
-        #[derive(Copy, Clone, bytemuck::Pod, Zeroable)]
-        struct Buffer<R> {
-            register: R,
-            crc: u8,
+        let mut array = ArrayVec::<_, 64>::new();
+        unsafe {
+            array.set_len(R::REGISTER_SIZE + R::REGISTER_SIZE / CHUNK_SIZE);
         }
-        let mut buffer = Buffer::<R>::zeroed();
-        let data = bytemuck::bytes_of_mut(&mut buffer);
 
-        bound_bus.interface.write_read(bound_bus.address, header, data).await?;
-        let register = buffer.register;
-        let crc = C::generate(register.data());
-        if crc != buffer.crc {
-            panic!("OhNo")
-        } else {
-            Ok(register)
+        bound_bus
+            .interface
+            .write_read(bound_bus.address, header, &mut array)
+            .await?;
+
+        let mut register = R::zeroed();
+        let data = bytemuck::bytes_of_mut(&mut register);
+        for (i, x) in array.chunks(CHUNK_SIZE + 1).enumerate() {
+            let value = &x[0..CHUNK_SIZE];
+            data[i..i + CHUNK_SIZE].copy_from_slice(value);
+            let crc_val = crc.checksum(value);
+            let crc_real = x[CHUNK_SIZE];
+            if crc_real != crc_val {
+                panic!("crc failed")
+            }
         }
+
+        Ok(register)
     }
 
     #[inline]
@@ -96,19 +106,24 @@ impl<const HEADER_SIZE: usize, C: Crc8Algorithm + 'static> crate::i2c::Codec for
         struct Buffer<const HEADER_SIZE: usize, R> {
             header: [u8; HEADER_SIZE],
             register: R,
-            crc: u8,
         }
+        let crc = crc::Crc::<u8>::new(C::new());
 
-        let crc = C::generate(register.as_ref().data());
         let mut buffer = Buffer::<{ HEADER_SIZE }, R> {
             header: R::ADDRESS.to_be_bytes()[core::mem::size_of_val(&R::ADDRESS) - HEADER_SIZE..]
                 .try_into()
                 .expect("Unexpected compile-time header address size. This is a bug in the chosen Codec or embedded-registers."),
             register: *register.as_ref(),
-            crc,
         };
-
         let data = bytemuck::bytes_of_mut(&mut buffer);
-        bound_bus.interface.write(bound_bus.address, data).await
+
+        let mut array = ArrayVec::<_, 64>::new();
+        for x in data.chunks(CHUNK_SIZE) {
+            array.try_extend_from_slice(x).unwrap();
+            let crc_val = crc.checksum(x);
+            array.push(crc_val);
+        }
+
+        bound_bus.interface.write(bound_bus.address, &array).await
     }
 }

--- a/embedded-registers/src/i2c/codecs/crc_codec.rs
+++ b/embedded-registers/src/i2c/codecs/crc_codec.rs
@@ -1,0 +1,114 @@
+use core::marker::PhantomData;
+
+use crate::{ReadableRegister, WritableRegister};
+use bytemuck::Zeroable;
+use crc::{Algorithm, CRC_8_NRSC_5};
+
+/// This codec represents the most commonly found codecs for I2C devices.
+/// The main variable is the size of register addresses in bytes.
+///
+/// This codec has no information over register sizes or the existence of
+/// read/write address-auto-increment which some devices support.
+/// It will always send one header and then receive/send the associated register data,
+/// so it's compatible with auto-increment usage, but cannot be used to read or write
+/// registers that require interspersing the address between bytes.
+///
+/// Devices often use a mixed mode, where some registers allow auto-increment while others
+/// don't, or where the address is directly associated with a specific, but varying, register size.
+/// Therefore, it is up to the user to make sure that accessing a register via this codec
+/// is supported by the hardware.
+///
+/// The following generic parameters are available:
+///
+/// | Parameter | Type | Description |
+/// |---|---|---|
+/// | `HEADER_SIZE` | `usize` | The size of the command header (register address) in bytes |
+#[derive(Default)]
+pub struct Crc8Codec<const HEADER_SIZE: usize, C: Crc8Algorithm> {
+    _algo: PhantomData<C>,
+}
+
+pub trait Crc8Algorithm: Default {
+    fn new() -> &'static Algorithm<u8>;
+    fn generate(bytes: &[u8]) -> u8 {
+        let crc = crc::Crc::<u8>::new(Self::new());
+        crc.checksum(bytes)
+    }
+}
+
+#[derive(Default)]
+struct MyCrc {}
+
+impl Crc8Algorithm for MyCrc {
+    fn new() -> &'static Algorithm<u8> {
+        const CUSTOM_ALG: crc::Algorithm<u8> = CRC_8_NRSC_5;
+        &CUSTOM_ALG
+    }
+}
+
+#[maybe_async_cfg::maybe(
+    idents(hal(sync = "embedded_hal", async = "embedded_hal_async"), Codec, I2cBoundBus),
+    sync(feature = "sync"),
+    async(feature = "async"),
+    keep_self
+)]
+impl<const HEADER_SIZE: usize, C: Crc8Algorithm + 'static> crate::i2c::Codec for Crc8Codec<HEADER_SIZE, C> {
+    #[inline]
+    async fn read_register<R, I, A>(bound_bus: &mut crate::i2c::I2cBoundBus<I, A>) -> Result<R, I::Error>
+    where
+        R: ReadableRegister,
+        I: hal::i2c::I2c<A> + hal::i2c::ErrorType,
+        A: hal::i2c::AddressMode + Copy,
+    {
+        let header = &R::ADDRESS.to_be_bytes()[core::mem::size_of_val(&R::ADDRESS) - HEADER_SIZE..];
+
+        #[repr(C, packed(1))]
+        #[derive(Copy, Clone, bytemuck::Pod, Zeroable)]
+        struct Buffer<R> {
+            register: R,
+            crc: u8,
+        }
+        let mut buffer = Buffer::<R>::zeroed();
+        let data = bytemuck::bytes_of_mut(&mut buffer);
+
+        bound_bus.interface.write_read(bound_bus.address, header, data).await?;
+        let register = buffer.register;
+        let crc = C::generate(register.data());
+        if crc != buffer.crc {
+            panic!("OhNo")
+        } else {
+            Ok(register)
+        }
+    }
+
+    #[inline]
+    async fn write_register<R, I, A>(
+        bound_bus: &mut crate::i2c::I2cBoundBus<I, A>,
+        register: impl AsRef<R>,
+    ) -> Result<(), I::Error>
+    where
+        R: WritableRegister,
+        I: hal::i2c::I2c<A> + hal::i2c::ErrorType,
+        A: hal::i2c::AddressMode + Copy,
+    {
+        #[repr(C, packed(1))]
+        #[derive(Copy, Clone, bytemuck::Pod, Zeroable)]
+        struct Buffer<const HEADER_SIZE: usize, R> {
+            header: [u8; HEADER_SIZE],
+            register: R,
+            crc: u8,
+        }
+
+        let crc = C::generate(register.as_ref().data());
+        let mut buffer = Buffer::<{ HEADER_SIZE }, R> {
+            header: R::ADDRESS.to_be_bytes()[core::mem::size_of_val(&R::ADDRESS) - HEADER_SIZE..]
+                .try_into()
+                .expect("Unexpected compile-time header address size. This is a bug in the chosen Codec or embedded-registers."),
+            register: *register.as_ref(),
+            crc,
+        };
+
+        let data = bytemuck::bytes_of_mut(&mut buffer);
+        bound_bus.interface.write(bound_bus.address, data).await
+    }
+}

--- a/embedded-registers/src/i2c/codecs/mod.rs
+++ b/embedded-registers/src/i2c/codecs/mod.rs
@@ -1,5 +1,9 @@
+mod crc_codec;
 mod no_codec;
 mod simple_codec;
+
+pub use crc_codec::Crc8Algorithm;
+pub use crc_codec::Crc8Codec;
 
 pub use no_codec::NoCodec;
 pub use simple_codec::SimpleCodec;


### PR DESCRIPTION
This adds support for the sensirion SCD4x devices, namely the SCD40 SCD41 and soon the SCD43.

These need an new codec as their i2c driver expects each message to be accompanied by a crc.
I have tried to make the crc driver somewhat generic, only the future will tell if that worked.

I have chosen to implement all three variants using the same struct as a base.
Only when calling init will the sensor check which variant is actually is and save it himself.
The SCD41 and SCD43 support some command that the SCD40 does not, it is thus currently possible
to try and access commands that may not exist. For the often used functionality, such as 
measuring I have implemented helper functions, that check which variant is in use and act accordingly.
