### PR TITLE
fix(veml7700): use sensor and measurement macros for illuminance

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -212,7 +212,7 @@ dependencies = [
  "maybe-async-cfg",
  "paste",
  "thiserror",
- "uom 0.38.0",
+ "uom",
 ]
 
 [[package]]
@@ -259,7 +259,7 @@ dependencies = [
  "maybe-async-cfg",
  "thiserror",
  "trybuild",
- "uom 0.37.0",
+ "uom",
 ]
 
 [[package]]
@@ -750,16 +750,6 @@ name = "unicode-xid"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
-
-[[package]]
-name = "uom"
-version = "0.37.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd5cfe7d84f6774726717f358a37f5bca8fca273bed4de40604ad129d1107b49"
-dependencies = [
- "num-traits",
- "typenum",
-]
 
 [[package]]
 name = "uom"

--- a/embedded-devices/src/devices/vishay/veml7700/mod.rs
+++ b/embedded-devices/src/devices/vishay/veml7700/mod.rs
@@ -64,8 +64,10 @@
 //! # }
 //! ```
 
-use embedded_devices_derive::forward_register_fns;
+use embedded_devices_derive::{forward_register_fns, sensor};
 use embedded_interfaces::TransportError;
+use uom::si::f64::Illuminance;
+use uom::si::illuminance::lux;
 
 use self::address::Address;
 
@@ -73,9 +75,6 @@ pub mod address;
 pub mod registers;
 
 use registers::{Configuration, PowerSaving};
-
-use uom::si::f64::Illuminance;
-use uom::si::illuminance::lux;
 
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
 #[derive(Debug, thiserror::Error)]
@@ -101,6 +100,7 @@ pub enum MeasurementError<BusError> {
 /// Measurement data
 #[derive(Debug, embedded_devices_derive::Measurement)]
 pub struct Measurement {
+    #[measurement(Illuminance)]
     pub lux: Illuminance,
 }
 
@@ -141,6 +141,7 @@ where
 }
 
 #[forward_register_fns]
+#[sensor(Illuminance)]
 #[maybe_async_cfg::maybe(
     idents(hal(sync = "embedded_hal", async = "embedded_hal_async"), RegisterInterface),
     sync(feature = "sync"),

--- a/embedded-devices/src/sensor.rs
+++ b/embedded-devices/src/sensor.rs
@@ -1,7 +1,7 @@
 use paste::paste;
 use uom::si::f64::{
-    ElectricCharge, ElectricCurrent, ElectricPotential, Energy, Frequency, MassConcentration, Power, Pressure, Ratio,
-    ThermodynamicTemperature, Velocity,
+    ElectricCharge, ElectricCurrent, ElectricPotential, Energy, Frequency, Illuminance, MassConcentration, Power,
+    Pressure, Ratio, ThermodynamicTemperature, Velocity,
 };
 
 /// This trait is implemented for any sensor specific measurement struct.
@@ -108,7 +108,7 @@ define_sensor_measurement!(Co2Concentration, Ratio, "CO2 concentration");
 define_sensor_measurement!(Current, ElectricCurrent, "current");
 define_sensor_measurement!(Energy, Energy, "energy");
 define_sensor_measurement!(HchoConcentration, Ratio, "HCHO concentration");
-// define_sensor_measurement!(Illuminance, Illuminance, "illuminance");
+define_sensor_measurement!(Illuminance, Illuminance, "illuminance");
 define_sensor_measurement!(NoxIndex, Ratio, "NOx index");
 define_sensor_measurement!(Pm10Concentration, MassConcentration, "PM10 concentration");
 define_sensor_measurement!(Pm1Concentration, MassConcentration, "PM1 concentration");


### PR DESCRIPTION
looks like I forgot this bit in #23, whoops :sweat_smile: 